### PR TITLE
Add dropout

### DIFF
--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -145,6 +145,7 @@ if __name__ == '__main__' :
             runningAccuracy = curAcc
             lastBest = globalCount
             lastSave = options.base + \
+                       '_dropout'+ str(options.dropout) + \
                        '_learnC' + str(options.learnC) + \
                        '_learnF' + str(options.learnF) + \
                        '_momentum' + str(options.momentum) + \

--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -23,6 +23,11 @@ if __name__ == '__main__' :
                         help='Rate of learning on Fully-Connected Layers.')
     parser.add_argument('--momentum', dest='momentum', type=float, default=.3,
                         help='Momentum rate all layers.')
+    parser.add_argument('--dropout', dest='dropout', type=bool, default=False,
+                        help='Enable dropout throughout the network. Dropout '\
+                             'percentages are based on optimal reported '\
+                             'results. NOTE: Networks using dropout need to '\
+                             'increase both neural breadth and learning rates')
     parser.add_argument('--kernel', dest='kernel', type=int, default=6,
                         help='Number of Convolutional Kernels in each Layer.')
     parser.add_argument('--neuron', dest='neuron', type=int, default=120,
@@ -37,11 +42,6 @@ if __name__ == '__main__' :
                         help='Batch size for training and test sets.')
     parser.add_argument('--base', dest='base', type=str, default='./leNet5',
                         help='Base name of the network output and temp files.')
-    parser.add_argument('--dropout', dest='dropout', type=bool, default=False,
-                        help='Enable dropout throughout the network. Dropout '\
-                             'percentages are based on optimal reported '\
-                             'results. NOTE: Networks using dropout need to '\
-                             'increase both neural breadth and learning rates')
     parser.add_argument('--syn', dest='synapse', type=str, default=None,
                         help='Load from a previously saved network.')
     parser.add_argument('data', help='Directory or pkl.gz file for the ' +
@@ -121,8 +121,7 @@ if __name__ == '__main__' :
         network.addLayer(ContiguousLayer(
             layerID='f4', input=network.getNetworkOutput(),
             inputSize=network.getNetworkOutputSize(), numNeurons=len(labels),
-            learningRate=options.learnF, activation=None,
-            dropout=.5 if options.dropout else 1., randomNumGen=rng))
+            learningRate=options.learnF, activation=None, randomNumGen=rng))
 
     globalCount = lastBest = degradationCount = 0
     numEpochs = options.limit

--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -17,9 +17,9 @@ if __name__ == '__main__' :
                         help='Specify log output file.')
     parser.add_argument('--level', dest='level', default='INFO', type=str, 
                         help='Log Level.')
-    parser.add_argument('--learnC', dest='learnC', type=float, default=.0031,
+    parser.add_argument('--learnC', dest='learnC', type=float, default=.031,
                         help='Rate of learning on Convolutional Layers.')
-    parser.add_argument('--learnF', dest='learnF', type=float, default=.0015,
+    parser.add_argument('--learnF', dest='learnF', type=float, default=.015,
                         help='Rate of learning on Fully-Connected Layers.')
     parser.add_argument('--momentum', dest='momentum', type=float, default=.3,
                         help='Momentum rate all layers.')
@@ -104,8 +104,7 @@ if __name__ == '__main__' :
         # this way we don't combine the channels kernels we created in 
         # the first layer and destroy our dimensionality
         network.addLayer(ConvolutionalLayer(
-            layerID='c2',
-            input=network.getNetworkOutput(), 
+            layerID='c2', input=network.getNetworkOutput(), 
             inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,

--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -92,7 +92,7 @@ if __name__ == '__main__' :
             inputSize=trainSize[1:],
             kernelSize=(options.kernel,trainSize[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
-            learningRate=options.learnC))
+            dropout=.8, learningRate=options.learnC))
 
         # refactor the output to be (numImages*numKernels, 1, numRows, numCols)
         # this way we don't combine the channels kernels we created in 
@@ -103,15 +103,15 @@ if __name__ == '__main__' :
             inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
-            learningRate=options.learnC))
+            dropout=.5, learningRate=options.learnC))
 
         # add fully connected layers
         network.addLayer(ContiguousLayer(
-            layerID='f3', input=network.getNetworkOutput().flatten(2),
+            layerID='f3', input=network.getNetworkOutput(),
             inputSize=(network.getNetworkOutputSize()[0], 
                        reduce(mul, network.getNetworkOutputSize()[1:])),
             numNeurons=options.neuron, learningRate=options.learnF,
-            randomNumGen=rng))
+            dropout=.5, randomNumGen=rng))
         network.addLayer(ContiguousLayer(
             layerID='f4', input=network.getNetworkOutput(),
             inputSize=network.getNetworkOutputSize(), numNeurons=len(labels),

--- a/trunk/apps/likenessFinder.py
+++ b/trunk/apps/likenessFinder.py
@@ -157,7 +157,7 @@ def createNetwork(image, log=None) :
         # add fully connected layers
         numInputs = reduce(mul, network.getNetworkOutputSize()[1:])
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput().flatten(2),
+            layerID='f3', input=network.getNetworkOutput(),
             inputSize=(network.getNetworkOutputSize()[0], numInputs),
             numNeurons=options.hidden,
             learningRate=options.learnF, randomNumGen=rng))
@@ -216,8 +216,7 @@ def createNetwork(image, log=None) :
                         print layerEpochStr + ' Cost: ' + str(locCost)
                     globCost.append(locCost)
 
-                    if ii == 0 :
-                        network.writeWeights(layerIndex, globalEpoch + localEpoch)
+                    network.writeWeights(layerIndex, globalEpoch + localEpoch)
                 globalEpoch = globalEpoch + options.numEpochs
                 network.save(options.base + str(layerIndex) + \
                              '_epoch' + str(globalEpoch) + \

--- a/trunk/apps/semiSupervisedTrainer.py
+++ b/trunk/apps/semiSupervisedTrainer.py
@@ -28,6 +28,7 @@ def trainUnsupervised(network, options) :
         globalEpoch, cost = network.trainEpoch(layerIndex, globalEpoch, 
                                                options.numEpochs)
         lastSave = options.base + \
+                   '_dropout'+ str(options.dropout) + \
                    '_learnC' + str(options.learnC) + \
                    '_learnF' + str(options.learnF) + \
                    '_contrF' + str(options.contrF) + \

--- a/trunk/apps/semiSupervisedTrainer.py
+++ b/trunk/apps/semiSupervisedTrainer.py
@@ -27,7 +27,6 @@ def trainUnsupervised(network, options) :
         globalEpoch = 0
         globalEpoch, cost = network.trainEpoch(layerIndex, globalEpoch, 
                                                options.numEpochs)
-        network.writeWeights(globalEpoch)
         lastSave = options.base + \
                    '_learnC' + str(options.learnC) + \
                    '_learnF' + str(options.learnF) + \
@@ -117,11 +116,16 @@ if __name__ == '__main__' :
                         help='Rate of learning on Convolutional Layers.')
     parser.add_argument('--learnF', dest='learnF', type=float, default=.0015,
                         help='Rate of learning on Fully-Connected Layers.')
-    parser.add_argument('--contrF', dest='contrF', type=float, default=.01,
+    parser.add_argument('--contrF', dest='contrF', type=float, default=None,
                         help='Rate of contraction of the latent space on ' +
                              'Fully-Connected Layers.')
     parser.add_argument('--momentum', dest='momentum', type=float, default=.3,
                         help='Momentum rate all layers.')
+    parser.add_argument('--dropout', dest='dropout', type=bool, default=False,
+                        help='Enable dropout throughout the network. Dropout '\
+                             'percentages are based on optimal reported '\
+                             'results. NOTE: Networks using dropout need to '\
+                             'increase both neural breadth and learning rates')
     parser.add_argument('--kernel', dest='kernel', type=int, default=6,
                         help='Number of Convolutional Kernels in each Layer.')
     parser.add_argument('--neuron', dest='neuron', type=int, default=120,
@@ -193,6 +197,7 @@ if __name__ == '__main__' :
             inputSize=trainShape[1:], 
             kernelSize=(options.kernel,trainShape[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
+            dropout=.8 if options.dropout else 1.,
             learningRate=options.learnC))
 
         # refactor the output to be (numImages*numKernels,1,numRows,numCols)
@@ -204,14 +209,16 @@ if __name__ == '__main__' :
             inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
+            dropout=.5 if options.dropout else 1.,
             learningRate=options.learnC))
 
         # add fully connected layers
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput().flatten(2),
+            layerID='f3', input=network.getNetworkOutput(),
             inputSize=(network.getNetworkOutputSize()[0], 
                        reduce(mul, network.getNetworkOutputSize()[1:])),
             numNeurons=options.neuron, learningRate=options.learnF,
+            dropout=.5 if options.dropout else 1.,
             randomNumGen=rng))
 
         # the final output layer is removed from the normal NN --
@@ -235,7 +242,7 @@ if __name__ == '__main__' :
     network.addLayer(ContiguousLayer(
         layerID='f4', input=network.getNetworkOutput(),
         inputSize=network.getNetworkOutputSize(), numNeurons=len(labels),
-        learningRate=options.learnF*10, randomNumGen=rng))
+        learningRate=options.learnF, randomNumGen=rng))
 
     # train the NN for supervised classification
     bestNetwork = trainSupervised(network, options)

--- a/trunk/apps/stackedPreTrainer.py
+++ b/trunk/apps/stackedPreTrainer.py
@@ -24,6 +24,11 @@ if __name__ == '__main__' :
     parser.add_argument('--contrF', dest='contrF', type=float, default=.01,
                         help='Rate of contraction of the latent space on ' +
                              'Fully-Connected Layers.')
+    parser.add_argument('--dropout', dest='dropout', type=bool, default=False,
+                        help='Enable dropout throughout the network. Dropout '\
+                             'percentages are based on optimal reported '\
+                             'results. NOTE: Networks using dropout need to '\
+                             'increase both neural breadth and learning rates')
     parser.add_argument('--kernel', dest='kernel', type=int, default=6,
                         help='Number of Convolutional Kernels in each Layer.')
     parser.add_argument('--neuron', dest='neuron', type=int, default=120,
@@ -88,6 +93,7 @@ if __name__ == '__main__' :
             inputSize=trainShape[1:], 
             kernelSize=(options.kernel,trainShape[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
+            dropout=.8 if options.dropout else 1.,
             learningRate=options.learnC))
 
         # refactor the output to be (numImages*numKernels, 1, numRows, numCols)
@@ -99,21 +105,22 @@ if __name__ == '__main__' :
             inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
+            dropout=.5 if options.dropout else 1., 
             learningRate=options.learnC))
 
         # add fully connected layers
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput().flatten(2),
+            layerID='f3', input=network.getNetworkOutput(),
             inputSize=(network.getNetworkOutputSize()[0], 
                        reduce(mul, network.getNetworkOutputSize()[1:])),
             numNeurons=options.neuron, learningRate=options.learnF,
-            randomNumGen=rng))
+            dropout=.5 if options.dropout else 1., randomNumGen=rng))
 
         # the final output layer is removed from the normal NN --
         # the output layer is special, as it makes decisions about
         # patterns identified in previous layers, so it should only
         # be influenced/trained during supervised learning. 
-    network.writeWeights(-1)
+    network.writeWeights(0, -1)
 
     # train each layer in sequence --
     # first we pre-train the data and at each epoch, we save it to disk
@@ -122,8 +129,9 @@ if __name__ == '__main__' :
         globalEpoch = 0
         globalEpoch, cost = network.trainEpoch(layerIndex, globalEpoch, 
                                                options.numEpochs)
-        network.writeWeights(globalEpoch)
+        network.writeWeights(layerIndex, globalEpoch)
         lastSave = options.base + \
+                   '_dropout'+ str(options.dropout) + \
                    '_learnC' + str(options.learnC) + \
                    '_learnF' + str(options.learnF) + \
                    '_contrF' + str(options.contrF) + \

--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -31,6 +31,10 @@ class ContractiveAutoEncoder(ContiguousLayer, AutoEncoder) :
        learningRate     : learning rate for all neurons
        contractionRate  : variance (dimensionality) reduction rate
                           None uses '1 / numNeurons'
+       dropout          : rate of retention in a given neuron during training
+                          NOTE: input layers should be around .8 or .9
+                                hidden layers should be around .5 or .6
+                                output layers should always be 1.
        initialWeights   : weights to initialize the network
                           None generates random weights for the layer
        initialHidThresh : thresholds to initialize the forward network

--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -41,8 +41,8 @@ class ContractiveAutoEncoder(ContiguousLayer, AutoEncoder) :
                           this must be a function with a derivative form
        randomNumGen     : generator for the initial weight values
     '''
-    def __init__ (self, layerID, input, inputSize, numNeurons,
-                  learningRate=0.001, contractionRate=None,
+    def __init__ (self, layerID, input, inputSize, numNeurons, 
+                  learningRate=0.001, dropout=None, contractionRate=None,
                   initialWeights=None, initialHidThresh=None,
                   initialVisThresh=None, activation=t.nnet.sigmoid,
                   randomNumGen=None) :
@@ -51,6 +51,7 @@ class ContractiveAutoEncoder(ContiguousLayer, AutoEncoder) :
                                  inputSize=inputSize,
                                  numNeurons=numNeurons,
                                  learningRate=learningRate,
+                                 dropout=dropout,
                                  initialWeights=initialWeights,
                                  initialThresholds=initialHidThresh,
                                  activation=activation, 

--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -121,19 +121,6 @@ class ContractiveAutoEncoder(ContiguousLayer, AutoEncoder) :
     # DEBUG: For Debugging purposes only
     def train(self, image) :
         return self._trainLayer(image)
-    # DEBUG: For Debugging purposes only
-    def writeWeights(self, ii, imageShape=None) :
-        from nn.debugger import saveTiledImage
-        if imageShape is None :
-            matSize = self._weights.get_value(borrow=True).shape
-            imageShape = ((matSize[1], matSize[0])),
-
-        # transpose the weight matrix to alighn the kernels contiguously
-        saveTiledImage(image=self._weights.get_value(borrow=True).T,
-                       path=self.layerID + '_cae_filters_' + str(ii) + '.png',
-                       imageShape=imageShape,
-                       spacing=1,
-                       interleave=True)
 
 if __name__ == '__main__' :
     import argparse, logging, time

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -62,7 +62,8 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
        randomNumGen     : generator for the initial weight values
     '''
     def __init__ (self, layerID, input, inputSize, kernelSize, 
-                  downsampleFactor, learningRate=0.001, contractionRate=0.01,
+                  downsampleFactor, learningRate=0.001,
+                  dropout=None, contractionRate=None,
                   initialWeights=None, initialHidThresh=None,
                   initialVisThresh=None, activation=t.nnet.sigmoid,
                   randomNumGen=None) :
@@ -72,6 +73,7 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
                                     kernelSize=kernelSize,
                                     downsampleFactor=downsampleFactor,
                                     learningRate=learningRate,
+                                    dropout=dropout,
                                     initialWeights=initialWeights,
                                     initialThresholds=initialHidThresh,
                                     activation=activation, 

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -11,27 +11,23 @@ def max_unpool_2d(input, upsampleFactor) :
        "Image Super-Resolution with Fast Approximate 
         Convolutional Sparse Coding"
     '''
-    output_shape = [
-        input.shape[1],
-        input.shape[2] * upsampleFactor[0],
-        input.shape[3] * upsampleFactor[1]
-    ]
-    stride = input.shape[2]
-    offset = input.shape[3]
-    in_dim = stride * offset
-    out_dim = in_dim * np.prod(upsampleFactor)
+    outputShape = [input.shape[1],
+                   input.shape[2] * upsampleFactor[0],
+                   input.shape[3] * upsampleFactor[1]]
+    numElems = input.shape[2] * input.shape[3]
+    upsampNumElems = numElems * np.prod(upsampleFactor)
 
-    upsamp_matrix = t.zeros((in_dim, out_dim))
-    rows = t.arange(in_dim)
+    upsamp = t.zeros((numElems, upsampNumElems))
+    rows = t.arange(numElems)
     cols = rows * upsampleFactor[0] + \
-           (rows / stride * upsampleFactor[1] * offset)
-    upsamp_matrix = t.set_subtensor(upsamp_matrix[rows, cols], 1.)
+           (rows / input.shape[2] * upsampleFactor[1] * input.shape[3])
+    upsamp = t.set_subtensor(upsamp[rows, cols], 1.)
 
-    flat = t.reshape(input, (input.shape[0], output_shape[0], 
+    flat = t.reshape(input, (input.shape[0], outputShape[0], 
                              input.shape[2] * input.shape[3]))
-    up_flat = t.dot(flat, upsamp_matrix)
-    return t.reshape(up_flat, (input.shape[0], output_shape[0],
-                               output_shape[1], output_shape[2]))
+    upsampflat = t.dot(flat, upsamp)
+    return t.reshape(upsampflat, (input.shape[0], outputShape[0],
+                                  outputShape[1], outputShape[2]))
 
 class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
     '''This class describes a Contractive AutoEncoder (CAE) for a convolutional
@@ -101,13 +97,13 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         # and runs the output back through the network in reverse. The net
         # effect is to reconstruct the input, and ultimately to see how well
         # the network is at encoding the message.
-        unpooling = max_unpool_2d(self.output, self._downsampleFactor)
+        unpooling = max_unpool_2d(self.output[1], self._downsampleFactor)
         deconvolve = conv2d(unpooling, self._weightsBack,
                             self.getFeatureSize(), kernelBackSize, 
                             border_mode='full')
         out = deconvolve + self._thresholdsBack.dimshuffle('x', 0, 'x', 'x')
         self._decodedInput = out if activation is None else activation(out)
-        self.reconstruction = function([self.input], self._decodedInput)
+        self.reconstruction = function([self.input[1]], self._decodedInput)
 
         # compute the jacobian cost of the output --
         # This works as a sparsity constraint in case the hidden vector is
@@ -123,9 +119,9 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         # NOTE: The jacobian was computed however takes much longer to process
         #       and does not help convergence or regularization. It was removed
         if activation == t.nnet.sigmoid :
-            self._cost = crossEntropyLoss(self.input, self._decodedInput, 1)
+            self._cost = crossEntropyLoss(self.input[1], self._decodedInput, 1)
         else :
-            self._cost = meanSquaredLoss(self.input, self._decodedInput)
+            self._cost = meanSquaredLoss(self.input[1], self._decodedInput)
 
         gradients = t.grad(self._cost + self._jacobianCost, self.getWeights())
         self._updates = [(weights, weights - learningRate * gradient)
@@ -135,7 +131,7 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         # TODO: this needs to be stackable and take the input to the first
         #       layer, not just the input of this layer. This will ensure
         #       the other layers are activated to get the input to this layer
-        self._trainLayer = function([self.input], 
+        self._trainLayer = function([self.input[1]], 
                                     [self._cost, self._jacobianCost],
                                     updates=self._updates)
 
@@ -157,17 +153,12 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         return self._trainLayer(image)
     # DEBUG: For Debugging purposes only 
     def writeWeights(self, ii) :
-        import PIL.Image as Image
-        from utils import tile_raster_images
-        kernelSize = self._weights.get_value(borrow=True).shape
-        img = Image.fromarray(tile_raster_images(
-        X=np.resize(self._weights.get_value(borrow=True),
-                    (kernelSize[0], kernelSize[1],
-                     kernelSize[2], kernelSize[3])),
-        img_shape=(kernelSize[2], kernelSize[3]), 
-        tile_shape=(kernelSize[0], kernelSize[1]),
-        tile_spacing=(1, 1)))
-        img.save(self.layerID + '_cae_filters_' + str(ii) + '.png')
+        from nn.debugger import saveTiledImage
+        saveTiledImage(image=self._weights.get_value(borrow=True),
+                       path=self.layerID + '_cae_filters_' + str(ii) + '.png',
+                       imageShape=(self._kernelSize[2], self._kernelSize[3]),
+                       spacing=1,
+                       interleave=True)
 
 if __name__ == '__main__' :
     import argparse, logging, time

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -53,6 +53,10 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
        learningRate     : learning rate for all neurons
        contractionRate  : variance (dimensionality) reduction rate
                           None uses '1 / numNeurons'
+       dropout          : rate of retention in a given neuron during training
+                          NOTE: input layers should be around .8 or .9
+                                hidden layers should be around .5 or .6
+                                output layers should always be 1.
        initialHidThresh : thresholds to initialize the forward network
                           None generates random thresholds for the layer
        initialVisThresh : thresholds to initialize the backward network

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -153,14 +153,7 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
     # DEBUG: For Debugging purposes only 
     def train(self, image) :
         return self._trainLayer(image)
-    # DEBUG: For Debugging purposes only 
-    def writeWeights(self, ii) :
-        from nn.debugger import saveTiledImage
-        saveTiledImage(image=self._weights.get_value(borrow=True),
-                       path=self.layerID + '_cae_filters_' + str(ii) + '.png',
-                       imageShape=(self._kernelSize[2], self._kernelSize[3]),
-                       spacing=1,
-                       interleave=True)
+
 
 if __name__ == '__main__' :
     import argparse, logging, time

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -25,7 +25,7 @@ class StackedAENetwork (Network) :
         out, updates = encoder.getUpdates()
         self._greedyTrainer.append(
             theano.function([self._indexVar], out, updates=updates,
-                            givens={self.getNetworkInput() : 
+                            givens={self.getNetworkInput()[1] : 
                                     self._trainData[self._indexVar]}))
 
     def __getstate__(self) :

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -109,14 +109,11 @@ class StackedAENetwork (Network) :
                 locCost.append(self.train(layerIndex, ii))
 
             locCost = np.mean(locCost, axis=0)
-            if isinstance(locCost, tuple) :
-                self._startProfile(layerEpochStr + ' Cost: ' + \
-                                   str(locCost[0]) + ' - Jacob: ' + \
-                                   str(locCost[1]), 'info')
-            else :
-                self._startProfile(layerEpochStr + ' Cost: ' + \
-                                   str(locCost), 'info')
+            self._startProfile(layerEpochStr + ' Cost: ' + \
+                               str(locCost[0]) + ' - Jacob: ' + \
+                               str(locCost[1]), 'info')
             globCost.append(locCost)
+
             self._endProfile()
             self._endProfile()
 

--- a/trunk/modules/python/nn/contiguousLayer.py
+++ b/trunk/modules/python/nn/contiguousLayer.py
@@ -29,7 +29,7 @@ class ContiguousLayer(Layer) :
     def __init__ (self, layerID, input, inputSize, numNeurons,
                   learningRate=0.001, dropout=None, initialWeights=None, 
                   initialThresholds=None, activation=tanh, randomNumGen=None) :
-        Layer.__init__(self, layerID, learningRate)
+        Layer.__init__(self, layerID, learningRate, dropout)
 
         # adjust the input for the correct number of dimensions        
         if isinstance(input, tuple) :
@@ -76,7 +76,7 @@ class ContiguousLayer(Layer) :
         outTrain = findLogit(self.input[1], self._weights, self._thresholds)
 
         # determine dropout if requested
-        if dropout is not None :
+        if self._dropout is not None :
             # here there are two possible paths --
             # outClass : path of execution intended for classification. Here
             #            all neurons are present and weights must be scaled by
@@ -87,9 +87,9 @@ class ContiguousLayer(Layer) :
             #            neuron's output goes through a Bernoulli Trial. This
             #            retains a neuron with the probability specified by the
             #            dropout factor.
-            outClass = outClass / dropout
+            outClass = outClass / self._dropout
             outTrain = switch(self._randStream.binomial(
-                size=(self._numNeurons,), p=dropout), outTrain, 0)
+                size=(self._numNeurons,), p=self._dropout), outTrain, 0)
 
         # activate the layer --
         # output is a tuple to represent two possible paths through the

--- a/trunk/modules/python/nn/contiguousLayer.py
+++ b/trunk/modules/python/nn/contiguousLayer.py
@@ -2,7 +2,7 @@ from layer import Layer
 import numpy as np
 from theano import config, shared, dot, function
 from theano.tensor.nnet import sigmoid
-from theano.tensor import tanh
+from theano.tensor import tanh, switch
 
 class ContiguousLayer(Layer) :
     '''This class describes a Contiguous Neural Layer.
@@ -13,21 +13,34 @@ class ContiguousLayer(Layer) :
                            be a tuple of size (batch size, input vector length)
        numNeurons        : number of neurons in this layer
        learningRate      : learning rate for all neurons
+       dropout           : rate of retention in a given neuron during training
+                           NOTE: input layers should be around .8 or .9
+                                 hidden layers should be around .5 or .6
+                                 output layers should always be 1.
        initialWeights    : weights to initialize the network
                            None generates random weights for the layer
        initialThresholds : thresholds to initialize the network
                            None generates random thresholds for the layer
        activation        : the sigmoid function to use for activation
                            this must be a function with a derivative form
-       randomNumGen      : generator for the initial weight values
+       randomNumGen      : generator for the initial weight values - 
+                           type is numpy.random.RandomState
     '''
     def __init__ (self, layerID, input, inputSize, numNeurons,
-                  learningRate=0.001, initialWeights=None,
+                  learningRate=0.001, dropout=None, initialWeights=None, 
                   initialThresholds=None, activation=tanh, randomNumGen=None) :
         Layer.__init__(self, layerID, learningRate)
 
-        # store the input buffer
-        self.input = input
+        # adjust the input for the correct number of dimensions        
+        if isinstance(input, tuple) :
+            if input[1].ndim > 2 : input = input[0].flatten(2), \
+                                           input[1].flatten(2)
+        else :
+            if input.ndim > 2 : input = input.flatten(2)
+
+        # store the input buffer -- this can either be a tuple or scalar
+        # The input layer will only have a scalar so its duplicated here
+        self.input = input if isinstance(input, tuple) else (input, input)
         self._inputSize = inputSize
         if isinstance(self._inputSize, long) or len(self._inputSize) is not 2 :
             self._inputSize = (1, inputSize)
@@ -56,9 +69,36 @@ class ContiguousLayer(Layer) :
                                          dtype=config.floatX)
         self._thresholds = shared(value=initialThresholds, borrow=True)
 
-        out = dot(self.input, self._weights) + self._thresholds
-        self.output = out if activation is None else activation(out)
-        self.activate = function([self.input], self.output)
+        # create the logits
+        def findLogit(input, weights, thresholds) :
+            return dot(input, weights) + thresholds
+        outClass = findLogit(self.input[0], self._weights, self._thresholds)
+        outTrain = findLogit(self.input[1], self._weights, self._thresholds)
+
+        # determine dropout if requested
+        if dropout is not None :
+            # here there are two possible paths --
+            # outClass : path of execution intended for classification. Here
+            #            all neurons are present and weights must be scaled by
+            #            the dropout factor. This ensures resultant 
+            #            probabilities fall within intended bounds when all
+            #            neurons are present.
+            # outTrain : path of execution for training with dropout. Here each
+            #            neuron's output goes through a Bernoulli Trial. This
+            #            retains a neuron with the probability specified by the
+            #            dropout factor.
+            outClass = outClass / dropout
+            outTrain = switch(self._randStream.binomial(
+                size=(self._numNeurons,), p=1-dropout), outTrain, 0)
+
+        # activate the layer --
+        # output is a tuple to represent two possible paths through the
+        # computation graph. 
+        self.output = (outClass, outTrain) if activation is None else \
+                      (activation(outClass), activation(outTrain))
+
+        # create a convenience function
+        self.activate = function([self.input[0]], self.output[0])
 
     def getWeights(self) :
         '''This allows the network backprop all layers efficiently.'''

--- a/trunk/modules/python/nn/contiguousLayer.py
+++ b/trunk/modules/python/nn/contiguousLayer.py
@@ -89,7 +89,7 @@ class ContiguousLayer(Layer) :
             #            dropout factor.
             outClass = outClass / dropout
             outTrain = switch(self._randStream.binomial(
-                size=(self._numNeurons,), p=1-dropout), outTrain, 0)
+                size=(self._numNeurons,), p=dropout), outTrain, 0)
 
         # activate the layer --
         # output is a tuple to represent two possible paths through the
@@ -109,3 +109,17 @@ class ContiguousLayer(Layer) :
     def getOutputSize (self) :
         '''(numInputs, number of neurons)'''
         return (self._inputSize[0], self._numNeurons)
+
+    # DEBUG: For Debugging purposes only
+    def writeWeights(self, ii, imageShape=None) :
+        from nn.debugger import saveTiledImage
+        matSize = self._weights.get_value(borrow=True).shape
+
+        # transpose the weight matrix to alighn the kernels contiguously
+        saveTiledImage(
+            image=self._weights.get_value(borrow=True).T,
+            path=self.layerID + '_cae_filters_' + str(ii) + '.png',
+            imageShape=(1, matSize[0]) if imageShape is None else imageShape,
+            tileShape=(matSize[1], 1) if imageShape is None else None,
+            spacing=0 if imageShape is None else 1,
+            interleave=True)

--- a/trunk/modules/python/nn/convolutionalLayer.py
+++ b/trunk/modules/python/nn/convolutionalLayer.py
@@ -109,7 +109,7 @@ class ConvolutionalLayer(Layer) :
             #            dropout factor.
             outClass = outClass / dropout
             outTrain = switch(self._randStream.binomial(
-                size=self.getOutputSize()[1:], p=1-dropout), outTrain, 0)
+                size=self.getOutputSize()[1:], p=dropout), outTrain, 0)
 
         # activate the layer --
         # output is a tuple to represent two possible paths through the
@@ -145,3 +145,12 @@ class ConvolutionalLayer(Layer) :
         return (fShape[0], fShape[1],
                 fShape[2] / self._downsampleFactor[0],
                 fShape[3] / self._downsampleFactor[1])
+
+    # DEBUG: For Debugging purposes only 
+    def writeWeights(self, ii) :
+        from nn.debugger import saveTiledImage
+        saveTiledImage(image=self._weights.get_value(borrow=True),
+                       path=self.layerID + '_cae_filters_' + str(ii) + '.png',
+                       imageShape=(self._kernelSize[2], self._kernelSize[3]),
+                       spacing=1,
+                       interleave=True)

--- a/trunk/modules/python/nn/convolutionalLayer.py
+++ b/trunk/modules/python/nn/convolutionalLayer.py
@@ -30,7 +30,7 @@ class ConvolutionalLayer(Layer) :
                   downsampleFactor, learningRate=0.001, dropout=None,
                   initialWeights=None, initialThresholds=None, activation=tanh,
                   randomNumGen=None) :
-        Layer.__init__(self, layerID, learningRate)
+        Layer.__init__(self, layerID, learningRate, dropout)
 
         # TODO: this check is likely unnecessary
         if inputSize[2] == kernelSize[2] or inputSize[3] == kernelSize[3] :
@@ -96,7 +96,7 @@ class ConvolutionalLayer(Layer) :
                               self._downsampleFactor, self._thresholds)
 
         # determine dropout if requested
-        if dropout is not None :
+        if self._dropout is not None :
             # here there are two possible paths --
             # outClass : path of execution intended for classification. Here
             #            all neurons are present and weights must be scaled by
@@ -107,9 +107,9 @@ class ConvolutionalLayer(Layer) :
             #            neuron's output goes through a Bernoulli Trial. This
             #            retains a neuron with the probability specified by the
             #            dropout factor.
-            outClass = outClass / dropout
+            outClass = outClass / self._dropout
             outTrain = switch(self._randStream.binomial(
-                size=self.getOutputSize()[1:], p=dropout), outTrain, 0)
+                size=self.getOutputSize()[1:], p=self._dropout), outTrain, 0)
 
         # activate the layer --
         # output is a tuple to represent two possible paths through the

--- a/trunk/modules/python/nn/costUtils.py
+++ b/trunk/modules/python/nn/costUtils.py
@@ -7,7 +7,7 @@ def crossEntropyLoss (p, q, axis=None):
         q    - the current estimate
         axis - the axis in which to sum across -- used for multi-dimensional
     '''
-    return t.mean(-t.sum(p * t.log(q) + (1 - p) * t.log(1 - q), axis=axis))
+    return t.mean(t.sum(t.nnet.binary_crossentropy(q, p), axis=axis))
 
 def meanSquaredLoss (p, q) :
     ''' for these purposes this is equivalent to Negative Log Likelihood

--- a/trunk/modules/python/nn/costUtils.py
+++ b/trunk/modules/python/nn/costUtils.py
@@ -24,10 +24,14 @@ def leastAbsoluteDeviation(a, batchSize=None, scaleFactor=1.) :
        batchSize   - number of inputs in the batchs
        scaleFactor - scale factor for the regularization
     '''
-    if batchSize is None :
-        return t.mean(t.sum(t.abs_(a)) // batchSize) * scaleFactor
+    if not isinstance(a, list) :
+        a = [a]
+    absSum = sum([t.sum(t.abs_(arr)) for arr in a])
+
+    if batchSize is not None :
+        return t.mean(absSum // batchSize) * scaleFactor
     else :
-        return t.sum(t.abs_(a)) * scaleFactor
+        return absSum * scaleFactor
 
 def leastSquares(a, batchSize=None, scaleFactor=1.) :
     '''L2-norm provides 'Least Squares' --
@@ -39,10 +43,14 @@ def leastSquares(a, batchSize=None, scaleFactor=1.) :
 
        NOTE: a decent scale factor may be the 1. / numNeurons
     '''
-    if batchSize is None :
-        return t.mean(t.sum(a ** 2) // batchSize) * scaleFactor
+    if not isinstance(a, list) :
+        a = [a]
+    sqSum = sum([t.sum(arr ** 2) for arr in a])
+
+    if batchSize is not None :
+        return t.mean(sqSum // batchSize) * scaleFactor
     else :
-        return t.mean(t.sum(t.abs_(a))) * scaleFactor
+        return sqSum * scaleFactor
 
 def computeJacobian(a, wrt, batchSize, inputSize, numNeurons) :
     ''' compute a jacobian for the matrix 'out' with respect to 'wrt'.

--- a/trunk/modules/python/nn/datasetUtils.py
+++ b/trunk/modules/python/nn/datasetUtils.py
@@ -96,21 +96,17 @@ def ingestImagery(filepath=None, shared=False, log=None) :
         return train, test, labels
 
 def normalize(v) :
-    '''Normalize a vector in a naive manner.
-       TODO: For SAR products, the data is Rayleigh distributed for the 
-             amplitude component, so it may be best to perform a more rigorous
-             remap here. Amplitude recognition can be affected greatly by the
-             strength of Rayleigh distribution.
-    '''
+    '''Normalize a vector in a naive manner.'''
     minimum, maximum = numpy.amin(v), numpy.amax(v)
     return (v - minimum) / (maximum - minimum)
 
 def convertPhaseAmp(imData, log=None) :
     '''Extract the phase and amplitude components of a complex number.
        This is assumed to be a better classifier than the raw IQ image.
-       TODO: the amplitude components are Rayleigh distributed and may need to
-             be remapped (using histoEq) to better fit the bit range. The 
-             NN weights may also correct for this.
+       TODO: For SAR products, the data is Rayleigh distributed for the 
+             amplitude component, so it may be best to perform a more rigorous
+             remap here. Amplitude recognition can be affected greatly by the
+             strength of Rayleigh distribution.
        TODO: Research other possible feature spaces which could elicit better
              learning or augment the phase/amp components.
     '''

--- a/trunk/modules/python/nn/debugger.py
+++ b/trunk/modules/python/nn/debugger.py
@@ -1,8 +1,9 @@
 import numpy as np
-from nn.datasetUtils import norm
+import PIL.Image as Image
+from nn.datasetUtils import normalize as norm
 
 def saveNormalizedImage(image, path) :
-    import PIL.Image as Image
+    '''Save the image to a file. This performs'''
     im = Image.fromarray(np.uint8(norm(image) * 255))
     im.save(path)
 
@@ -11,47 +12,61 @@ def saveTiledImage(image, path, imageShape, spacing,
     '''Create a tiled image of the weights. 
     '''
     import cv2
+
     im = image
-    if len(image.shape) == 2 :
-        im = im.reshape((1, image.shape[0], image.shape[1]))
-    numChannels = image.shape[0]
+    if len(image.shape) == 4 :
+        im = im.reshape((image.shape[0], image.shape[1], 
+                         image.shape[2] * image.shape[3]))
+    elif len(image.shape) == 2 :
+        im = im.reshape((image.shape[0], 1, image.shape[1]))
+    numChannels = im.shape[1]
+
+    # reset if the input doesn't support
+    if numChannels != 3 :
+        interleave = False
 
     # calculate an appropriate tiling for the image
-    imNumPixels = imageShape[0] * imageShape[1]
     if tileShape is None :
         import math
-        totNumPixels = im.shape[0] * im.shape[1]
-        numTiles = math.ceil(totNumPixels / imNumPixels)
-        colTiles = math.ceil(math.sqrt(numTiles))
-        tileShape = (math.ceil(numTiles / colTiles), colTiles)
-    print "tileShape: " + str(tileShape)
+        colTiles = math.ceil(math.sqrt(im.shape[0]))
+        tileShape = (int(math.ceil(im.shape[0] / colTiles)), int(colTiles))
 
     # create a buffer for the output image
     outputShape = (numChannels,
-                   imageShape[0] + spacing * tileShape[0] - spacing,
-                   imageShape[1] + spacing * tileShape[1] - spacing)
+                   (imageShape[0] + spacing) * tileShape[0] - spacing,
+                   (imageShape[1] + spacing) * tileShape[1] - spacing)
     output = np.zeros(outputShape, dtype='uint8')
-    print "outputShape: " + str(outputShape)
 
     # populate the tiles with the pixel data
     for ii in range(tileShape[0]) :
         for jj in range(tileShape[1]) :
             # NOTE: we assume the images are aligned in each row
             imageOffset = ii * tileShape[1] + jj
-            if imageOffset < im.shape[1] :
 
-                # collect each chip for the channels
-                chip = norm(im[:, imageOffset : imageOffset + imNumPixels])
-                chip = chip.reshape(imageShape) * 255
+            # collect each chip for the channels
+            chip = norm(im[imageOffset, :, :]) * 255
+            chip = chip.reshape((numChannels,
+                                 imageShape[0],
+                                 imageShape[1]))
 
-                # align into the output buffer -- BGR for openCV
-                outLoc = (ii * (imageShape[0] + spacing),
-                          jj * (imageShape[1] + spacing[1]))
+            # align into the output buffer -- BGR for openCV
+            outLoc = (ii * (imageShape[0] + spacing),
+                      jj * (imageShape[1] + spacing))
+            if numChannels == 3 :
                 output[:, outLoc[0] : outLoc[0] + imageShape[0],
                           outLoc[1] : outLoc[1] + imageShape[1]] = \
-                      chip[[2,1,0],:,:]
+                    chip[[2,1,0],:,:]
+            else :
+                output[:, outLoc[0] : outLoc[0] + imageShape[0],
+                          outLoc[1] : outLoc[1] + imageShape[1]] = \
+                    chip[:,:,:]
 
-    # write the image to disk
-    cv2.imshow("open", output)
-    #cv2.imwrite(path, output)
-    return output
+    if interleave :
+        # write the image to disk
+        cv2.imshow("open", output)
+        #cv2.imwrite(path, output)
+    else :
+        output = output.reshape((outputShape[0] * outputShape[1], 
+                                 outputShape[2]))
+        im = Image.fromarray(output)
+        im.save(path)

--- a/trunk/modules/python/nn/debugger.py
+++ b/trunk/modules/python/nn/debugger.py
@@ -3,13 +3,29 @@ import PIL.Image as Image
 from nn.datasetUtils import normalize as norm
 
 def saveNormalizedImage(image, path) :
-    '''Save the image to a file. This performs'''
-    im = Image.fromarray(np.uint8(norm(image) * 255))
-    im.save(path)
+    '''Save the image to a file. This performs a naive normalization of the 
+       array and outputs a grey scale image. The input is assumed to be float
+       data.
+
+       image: 2D tensor (rows, cols)
+       path:  output path to image
+    '''
+    Image.fromarray(np.uint8(norm(image) * 255)).save(path)
 
 def saveTiledImage(image, path, imageShape, spacing,
                    tileShape=None, interleave=True) :
-    '''Create a tiled image of the weights. 
+    '''Create a tiled image of the weights 
+
+       image:      tensor to convert to a tiled image
+                   2D tensor (numKernels, inputSize)
+                   3D tensor (numKernels, numChannels, inputSize)
+                   4D tensor (numKernels, numChannels, numRows, numCols)
+       path:       output path to image
+       imageShape: shape of each tiled image in output
+       spacing:    size of pixel border around each tileShape
+       tileShape:  user-specified tiling pattern
+       interleave: create a colorize output image from channels
+                   False will separate and stack the image channels
     '''
     import cv2
 
@@ -63,12 +79,12 @@ def saveTiledImage(image, path, imageShape, spacing,
                               outLoc[1] : outLoc[1] + imageShape[1]] = \
                         chip[:,:,:]
 
+    # write the image to disk
     if interleave :
-        # write the image to disk
-        cv2.imshow("open", output)
-        #cv2.imwrite(path, output)
+        # openCV automatically interleaves the output
+        cv2.imwrite(path, output)
     else :
+        # PIL will write the output in its current (stacked) format
         output = output.reshape((outputShape[0] * outputShape[1], 
                                  outputShape[2]))
-        im = Image.fromarray(output)
-        im.save(path)
+        Image.fromarray(output).save(path)

--- a/trunk/modules/python/nn/debugger.py
+++ b/trunk/modules/python/nn/debugger.py
@@ -40,26 +40,28 @@ def saveTiledImage(image, path, imageShape, spacing,
     # populate the tiles with the pixel data
     for ii in range(tileShape[0]) :
         for jj in range(tileShape[1]) :
+
             # NOTE: we assume the images are aligned in each row
             imageOffset = ii * tileShape[1] + jj
 
-            # collect each chip for the channels
-            chip = norm(im[imageOffset, :, :]) * 255
-            chip = chip.reshape((numChannels,
-                                 imageShape[0],
-                                 imageShape[1]))
+            if imageOffset < im.shape[0] :
+                # collect each chip for the channels
+                chip = norm(im[imageOffset, :, :]) * 255
+                chip = chip.reshape((numChannels,
+                                     imageShape[0],
+                                     imageShape[1]))
 
-            # align into the output buffer -- BGR for openCV
-            outLoc = (ii * (imageShape[0] + spacing),
-                      jj * (imageShape[1] + spacing))
-            if numChannels == 3 :
-                output[:, outLoc[0] : outLoc[0] + imageShape[0],
-                          outLoc[1] : outLoc[1] + imageShape[1]] = \
-                    chip[[2,1,0],:,:]
-            else :
-                output[:, outLoc[0] : outLoc[0] + imageShape[0],
-                          outLoc[1] : outLoc[1] + imageShape[1]] = \
-                    chip[:,:,:]
+                # align into the output buffer -- BGR for openCV
+                outLoc = (ii * (imageShape[0] + spacing),
+                          jj * (imageShape[1] + spacing))
+                if numChannels == 3 :
+                    output[:, outLoc[0] : outLoc[0] + imageShape[0],
+                              outLoc[1] : outLoc[1] + imageShape[1]] = \
+                        chip[[2,1,0],:,:]
+                else :
+                    output[:, outLoc[0] : outLoc[0] + imageShape[0],
+                              outLoc[1] : outLoc[1] + imageShape[1]] = \
+                        chip[:,:,:]
 
     if interleave :
         # write the image to disk

--- a/trunk/modules/python/nn/debugger.py
+++ b/trunk/modules/python/nn/debugger.py
@@ -1,0 +1,57 @@
+import numpy as np
+from nn.datasetUtils import norm
+
+def saveNormalizedImage(image, path) :
+    import PIL.Image as Image
+    im = Image.fromarray(np.uint8(norm(image) * 255))
+    im.save(path)
+
+def saveTiledImage(image, path, imageShape, spacing,
+                   tileShape=None, interleave=True) :
+    '''Create a tiled image of the weights. 
+    '''
+    import cv2
+    im = image
+    if len(image.shape) == 2 :
+        im = im.reshape((1, image.shape[0], image.shape[1]))
+    numChannels = image.shape[0]
+
+    # calculate an appropriate tiling for the image
+    imNumPixels = imageShape[0] * imageShape[1]
+    if tileShape is None :
+        import math
+        totNumPixels = im.shape[0] * im.shape[1]
+        numTiles = math.ceil(totNumPixels / imNumPixels)
+        colTiles = math.ceil(math.sqrt(numTiles))
+        tileShape = (math.ceil(numTiles / colTiles), colTiles)
+    print "tileShape: " + str(tileShape)
+
+    # create a buffer for the output image
+    outputShape = (numChannels,
+                   imageShape[0] + spacing * tileShape[0] - spacing,
+                   imageShape[1] + spacing * tileShape[1] - spacing)
+    output = np.zeros(outputShape, dtype='uint8')
+    print "outputShape: " + str(outputShape)
+
+    # populate the tiles with the pixel data
+    for ii in range(tileShape[0]) :
+        for jj in range(tileShape[1]) :
+            # NOTE: we assume the images are aligned in each row
+            imageOffset = ii * tileShape[1] + jj
+            if imageOffset < im.shape[1] :
+
+                # collect each chip for the channels
+                chip = norm(im[:, imageOffset : imageOffset + imNumPixels])
+                chip = chip.reshape(imageShape) * 255
+
+                # align into the output buffer -- BGR for openCV
+                outLoc = (ii * (imageShape[0] + spacing),
+                          jj * (imageShape[1] + spacing[1]))
+                output[:, outLoc[0] : outLoc[0] + imageShape[0],
+                          outLoc[1] : outLoc[1] + imageShape[1]] = \
+                      chip[[2,1,0],:,:]
+
+    # write the image to disk
+    cv2.imshow("open", output)
+    #cv2.imwrite(path, output)
+    return output

--- a/trunk/modules/python/nn/layer.py
+++ b/trunk/modules/python/nn/layer.py
@@ -1,10 +1,18 @@
+from theano.tensor.shared_randomstreams import RandomStreams
+from time import time
+
 class Layer () :
+    # rng is across all layer types
+    _randStream = RandomStreams(int(time()))
+
     def __init__ (self, layerID, learningRate=0.001) :
         '''This class describes an abstract Neural Layer.
            layerID      : unique name identifier for this layer
            learningRate : multiplier for speed of gradient descent 
         '''
+        # input can be a tuple or a variable
         self.input = None
+        # output must be a tuple
         self.output = None
         self.layerID = layerID
         self._learningRate = learningRate

--- a/trunk/modules/python/nn/layer.py
+++ b/trunk/modules/python/nn/layer.py
@@ -5,10 +5,11 @@ class Layer () :
     # rng is across all layer types
     _randStream = RandomStreams(int(time()))
 
-    def __init__ (self, layerID, learningRate=0.001) :
+    def __init__ (self, layerID, learningRate=0.001, dropout=None) :
         '''This class describes an abstract Neural Layer.
            layerID      : unique name identifier for this layer
            learningRate : multiplier for speed of gradient descent 
+           dropout      : rate of retention in a given neuron during training
         '''
         # input can be a tuple or a variable
         self.input = None
@@ -16,6 +17,7 @@ class Layer () :
         self.output = None
         self.layerID = layerID
         self._learningRate = learningRate
+        self._dropout = dropout
 
     def getWeights(self) :
         raise NotImplementedError('Implement the getWeights() method')

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -341,8 +341,10 @@ class TrainerNetwork (ClassifierNetwork) :
             inputs=[expectedLabels, outputSize], outputs=result)
 
         # protect the loss function against producing NaNs
-        self._out = t.switch(self._out < 0.0001, 0.0001, self._out)
-        self._out = t.switch(self._out > 0.9999, 0.9999, self._out)
+        self._outTrainSoft = t.switch(self._outTrainSoft < 0.0001, 0.0001, 
+                                      self._outTrainSoft)
+        self._outTrainSoft = t.switch(self._outTrainSoft > 0.9999, 0.9999,
+                                      self._outTrainSoft)
 
         # create the cross entropy function --
         # This is the cost function for the network, and it assumes [0,1]

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -421,6 +421,9 @@ class TrainerNetwork (ClassifierNetwork) :
            numEpochs   : number of epochs to train this round before stopping
         '''
         for localEpoch in range(numEpochs) :
+            # DEBUG: For Debugging purposes only 
+            for layer in self._layers :
+                layer.writeWeights(globalEpoch + localEpoch)
             self._startProfile('Running Epoch [' + 
                                str(globalEpoch + localEpoch) + ']', 'info')
             for ii in range(self._numTrainBatches) :

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -361,8 +361,9 @@ class TrainerNetwork (ClassifierNetwork) :
         # L2-norm provides 'Least Squares' --
         # built for dense outputs and is computationally stable at small errors
         elif self._regularization == 'L2' :
-            reg = leastSquares([l.getWeights()[0] + l.getWeights()[1] \
-                                for l in self._layers], self._regScaleFactor)
+            reg = leastSquares(
+                [l.getWeights()[0] for l in self._layers],
+                self._regScaleFactor)
 
 
         # create the function for back propagation of all layers --


### PR DESCRIPTION
Input and output now allows two execution paths for classifying and training. Dropout performs either dropout or appropriate scaling. Moving writeWeights to the base class. costUtils.py now using theano built-in functionality, and updated regularization methods to start working. To test everything, a new debugger.py was created to dump the weights/reconstructed images for visualization purposes.
