### PR TITLE
Advance global count for synapse

### DIFF
--- a/trunk/apps/stackedPreTrainer.py
+++ b/trunk/apps/stackedPreTrainer.py
@@ -3,6 +3,7 @@ from ae.net import StackedAENetwork
 from ae.contiguousAE import ContractiveAutoEncoder
 from ae.convolutionalAE import ConvolutionalAutoEncoder
 from dataset.reader import ingestImagery, pickleDataset
+from dataset.writer import buildPickleInterim, buildPickleFinal
 from dataset.shared import splitToShared
 import os, argparse, logging
 from time import time
@@ -131,21 +132,21 @@ if __name__ == '__main__' :
         globalEpoch, cost = network.trainEpoch(layerIndex, globalEpoch, 
                                                options.numEpochs)
         network.writeWeights(layerIndex, globalEpoch)
-        lastSave = options.base + \
-                   '_dropout'+ str(options.dropout) + \
-                   '_learnC' + str(options.learnC) + \
-                   '_learnF' + str(options.learnF) + \
-                   '_contrF' + str(options.contrF) + \
-                   '_kernel' + str(options.kernel) + \
-                   '_neuron' + str(options.neuron) + \
-                   '_layer' + str(layerIndex) + \
-                   '_epoch' + str(globalEpoch) + '.pkl.gz'
+        lastSave = buildPickleInterim(base=options.base,
+                                      epoch=globalEpoch,
+                                      dropout=options.dropout,
+                                      learnC=options.learnC,
+                                      learnF=options.learnF,
+                                      contrF=options.contrF,
+                                      kernel=options.kernel,
+                                      neuron=options.neuron,
+                                      layer=layerIndex)
         network.save(lastSave)
 
     # rename the network which achieved the highest accuracy
-    bestNetwork = options.base + '_PreTrained_' + \
-                  os.path.basename(options.data) + '_epoch' + \
-                  str(options.numEpochs) + '.pkl.gz'
+    bestNetwork = buildPickleFinal(base=options.base, appName=__file__, 
+                                   dataName=os.path.basename(options.data), 
+                                   epoch=options.numEpochs)
     log.info('Renaming Best Network to [' + bestNetwork + ']')
     if os.path.exists(bestNetwork) :
         os.remove(bestNetwork)

--- a/trunk/modules/python/dataset/writer.py
+++ b/trunk/modules/python/dataset/writer.py
@@ -1,0 +1,44 @@
+
+def buildPickleInterim(base, epoch, dropout=None, learnC=None, learnF=None, 
+                       contrF=None, momentum=None, kernel=None, 
+                       neuron=None, layer=None) :
+    '''Create a structured name for the intermediate synapse.'''
+    outName = base
+    if dropout is not None :
+        outName += '_dropout'+ str(dropout)
+    if learnC is not None :
+        outName += '_learnC'+ str(learnC)
+    if learnF is not None :
+        outName += '_learnF'+ str(learnF)
+    if contrF is not None :
+        outName += '_contrF'+ str(contrF)
+    if momentum is not None :
+        outName += '_momentum'+ str(momentum)
+    if kernel is not None :
+        outName += '_kernel'+ str(kernel)
+    if neuron is not None :
+        outName += '_neuron'+ str(neuron)
+    if layer is not None :
+        outName += '_layer'+ str(layer)
+    outName += '_epoch' + str(epoch) + '.pkl.gz'
+    return outName
+
+def buildPickleFinal(base, appName, dataName, epoch, 
+                     accuracy=None, cost=None) :
+    '''Create a structured name for the final synapse.'''
+    from os.path import splitext
+    outName = base + 'Final_' + str(splitext(appName)[0]) + '_' + str(dataName)
+    if accuracy is not None :
+        outName += '_acc'+ str(accuracy)
+    if cost is not None :
+        outName += '_cost'+ str(cost)
+    outName += '_epoch' + str(epoch) + '.pkl.gz'
+    return outName
+
+def resumeEpoch(synapse) :
+    '''Return the epoch number for this synapse file. If it cannot be 
+       determined, zero will be returned. 
+    '''
+    import re
+    return 0 if synapse is None or 'epoch' not in synapse else \
+           int(re.findall(r'(?<=epoch)\d+', synapse)[0])


### PR DESCRIPTION
This is two small commits. First the trainer is now able to resume on the global epoch number when a synapse file is used. Second the naming utilities for saving pickles were similar enough that common utilities were made to perform this work. 
