### PR TITLE
Allow vector train labels

### DIFF
--- a/trunk/modules/python/dataset/shared.py
+++ b/trunk/modules/python/dataset/shared.py
@@ -9,15 +9,19 @@ def loadShared(x, borrow=True, log=None) :
         log.debug('Wrap memory into shared variables')
     return t.shared(np.asarray(x, dtype=t.config.floatX), borrow=borrow)
 
-def splitToShared(x, borrow=True, log=None) :
+def splitToShared(x, borrow=True, castInt=True, log=None) :
     '''Create shared variables for both the input and expectedOutcome vectors.
        x      : This can be a vector list of inputs and expectedOutputs. It is
                 assumed they are of the same length.
                     Format - (data, label)
-       borrow : Should the theano vector accept responsibility for the memory
+       borrow : Should the theano vector use the same buffer as numpy
+       castInt: Should the label be casted into int32
        return : Shared Variable equivalents for these items
                     Format - (data, label)
     '''
     data, label = x
-    return (loadShared(data, borrow, log), 
-            t.tensor.cast(loadShared(label, borrow, log), 'int32'))
+    data = loadShared(data, borrow, log)
+    label = loadShared(label, borrow, log)
+    if castInt :
+        label = t.tensor.cast(label, 'int32')
+    return data, label


### PR DESCRIPTION
This re-exposes the old vector way of expectedOutputs. This way was optimized for the GPU and allows for the upcoming soft-vectors distillery updates.

This now allows for two paths for training. The user can still support the one-hot vector using a index (for memory optimization). This additionally allows the user to pass in the full expected vector which will be used when making a distillery. 

This is new path was previously used, but is untested at this time.
