### PR TITLE
Shared one hots

### DIFF
--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -7,7 +7,6 @@ from nn.net import TrainerNetwork as Net
 from nn.contiguousLayer import ContiguousLayer
 from nn.convolutionalLayer import ConvolutionalLayer
 from dataset.ingest.labeled import ingestImagery
-from dataset.shared import splitToShared
 from nn.trainUtils import trainSupervised
 from nn.profiler import setupLogging
 
@@ -64,17 +63,14 @@ if __name__ == '__main__' :
 
     # NOTE: The pickleDataset will silently use previously created pickles if
     #       one exists (for efficiency). So watch out for stale pickles!
-    train, test, labels = ingestImagery(filepath=options.data, shared=False,
+    train, test, labels = ingestImagery(filepath=options.data, shared=True,
                                         batchSize=options.batchSize, 
                                         holdoutPercentage=options.holdout, 
                                         log=log)
-    trainSize = train[0].shape
-
-    tr = splitToShared(train, borrow=True)
-    te = splitToShared(test,  borrow=True)
+    trainSize = train[0].shape.eval()
 
     # create the network -- LeNet-5
-    network = Net(train, te, labels, regType='L2',
+    network = Net(train, test, labels, regType='L2',
                   regScaleFactor=1. / (options.kernel + options.kernel + 
                                        options.neuron + len(labels)), 
                   log=log)

--- a/trunk/apps/semiSupervisedTrainer.py
+++ b/trunk/apps/semiSupervisedTrainer.py
@@ -4,7 +4,6 @@ from ae.net import StackedAENetwork
 from ae.contiguousAE import ContractiveAutoEncoder
 from ae.convolutionalAE import ConvolutionalAutoEncoder
 from dataset.ingest.labeled import ingestImagery
-from dataset.shared import splitToShared
 from nn.contiguousLayer import ContiguousLayer
 from nn.trainUtils import trainUnsupervised, trainSupervised
 from nn.net import TrainerNetwork
@@ -76,14 +75,14 @@ if __name__ == '__main__' :
 
     # NOTE: The pickleDataset will silently use previously created pickles if
     #       one exists (for efficiency). So watch out for stale pickles!
-    train, test, labels = ingestImagery(filepath=options.data, shared=False,
+    train, test, labels = ingestImagery(filepath=options.data, shared=True,
                                         batchSize=options.batchSize, 
                                         holdoutPercentage=options.holdout, 
                                         log=log)
-    trainShape = train[0].shape
+    trainShape = train[0].shape.eval()
 
     # create the stacked network -- LeNet-5 (minus the output layer)
-    network = StackedAENetwork(splitToShared(train, borrow=True), log=log)
+    network = StackedAENetwork(train, log=log)
 
     if options.synapse is not None :
         # load a previously saved network
@@ -145,7 +144,7 @@ if __name__ == '__main__' :
     # translate into a neural network --
     # this transfers our unsupervised pre-training into a decent
     # starting condition for our supervised learning
-    network = TrainerNetwork(train, splitToShared(test,  borrow=True), labels,
+    network = TrainerNetwork(train, test, labels,
                              filepath=bestNetwork, log=log)
 
     # add the classification layer

--- a/trunk/apps/stackedPreTrainer.py
+++ b/trunk/apps/stackedPreTrainer.py
@@ -8,7 +8,6 @@ from ae.contiguousAE import ContractiveAutoEncoder
 from ae.convolutionalAE import ConvolutionalAutoEncoder
 from dataset.ingest.labeled import ingestImagery
 from nn.trainUtils import trainUnsupervised
-from dataset.shared import splitToShared
 from nn.profiler import setupLogging
 
 '''This is an example Stacked AutoEncoder used for unsupervised pre-training.
@@ -63,14 +62,14 @@ if __name__ == '__main__' :
 
     # NOTE: The pickleDataset will silently use previously created pickles if
     #       one exists (for efficiency). So watch out for stale pickles!
-    train, test, labels = ingestImagery(filepath=options.data, shared=False,
+    train, test, labels = ingestImagery(filepath=options.data, shared=True,
                                         batchSize=options.batchSize, 
                                         holdoutPercentage=options.holdout, 
                                         log=log)
     trainShape = train[0].shape
 
     # create the stacked network -- LeNet-5 (minus the output layer)
-    network = StackedAENetwork(splitToShared(train, borrow=True), log=log)
+    network = StackedAENetwork(train, log=log)
 
     if options.synapse is not None :
         # load a previously saved network

--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -182,5 +182,5 @@ if __name__ == '__main__' :
         saveTiledImage(image=ae.reconstruction(train[0][0]),
                        path='cae_filters_reconstructed_' + str(ii+1) + '.png',
                        imageShape=(28, 28), spacing=1)
-        print 'Epoch [' + str(ii) + ']: ' + str(ae.train(train[0][0])) + \
-              ' ' + str(time.time() - start) + 's'
+        print('Epoch [' + str(ii) + ']: ' + str(ae.train(train[0][0])) + \
+              ' ' + str(time.time() - start) + 's')

--- a/trunk/modules/python/nn/costUtils.py
+++ b/trunk/modules/python/nn/costUtils.py
@@ -5,15 +5,28 @@ def cropExtremes(x) :
     return t.clip(x, 1e-7, 1.0 - 1e-7)
 
 def crossEntropyLoss (p, q, axis=None, crop=True):
-    ''' for these purposes this is equivalent to Negative Log Likelihood
-        this is the average of all cross-entropies in our guess
-        p    : the target value
-        q    : the current estimate
-        axis : the axis in which to sum across -- used for multi-dimensional
-        crop :
+    '''For these purposes this is equivalent to Negative Log Likelihood
+       this is the average of all cross-entropies in our guess
+
+       NOTE: This method supports two modes. The target values can be specified
+             as either a fmatrix or an ivector. The fmatrix is represented as
+             (batchSize, denseTarget). The ivector is a single dimension where 
+             the vector length is the batchSize and the number in the ith 
+             position is the index into the one hot vector where the one 
+             resides. This ivector representation is a more compact way of 
+             representing one-hot encodings.
+
+       p    : the target value
+       q    : the current estimate
+       axis : the axis in which to sum across -- used for multi-dimensional
+       crop : crop the extremes to protect against segmentation faults
     '''
-    if crop : q = cropExtremes(q)
-    return t.mean(t.sum(t.nnet.binary_crossentropy(q, p), axis=axis))
+    if crop : 
+        q = cropExtremes(q)
+    if p.ndim == 2 :
+        return t.mean(t.sum(t.nnet.binary_crossentropy(q, p), axis=axis))
+    else :
+        return t.mean(t.nnet.crossentropy_categorical_1hot(q, p))
 
 def meanSquaredLoss (p, q) :
     ''' for these purposes this is equivalent to Negative Log Likelihood

--- a/trunk/projects/distillery/shallowNet.py
+++ b/trunk/projects/distillery/shallowNet.py
@@ -1,6 +1,7 @@
 import theano.tensor as t
 import argparse
 from time import time
+from six.moves import reduce
 
 from nn.net import ClassifierNetwork as Net
 from nn.contiguousLayer import ContiguousLayer

--- a/trunk/projects/unsupervised/multiInputRandomTrainer.py
+++ b/trunk/projects/unsupervised/multiInputRandomTrainer.py
@@ -1,6 +1,7 @@
 import theano.tensor as t
 import argparse
 from time import time
+from six.moves import reduce
 
 from ae.net import StackedAENetwork
 from ae.contiguousAE import ContractiveAutoEncoder


### PR DESCRIPTION
Updates to use the compact version of the one hot labels to train the network. This uses less memory and can now be loaded into shared variables. The processing on a shallow network (2conv 2full) on MNIST went from 40.5s down to 22.9s for two epochs and an accCheck.

Also fixed some remaining python 3 support issues.
