### PR TITLE
Adaptable pickles

### DIFF
--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -1,4 +1,3 @@
-import theano.tensor as t
 import argparse
 from time import time
 from six.moves import reduce

--- a/trunk/apps/leNet5Trainer.py
+++ b/trunk/apps/leNet5Trainer.py
@@ -8,7 +8,7 @@ from nn.contiguousLayer import ContiguousLayer
 from nn.convolutionalLayer import ConvolutionalLayer
 from dataset.ingest.labeled import ingestImagery
 from nn.trainUtils import trainSupervised
-from nn.profiler import setupLogging
+from nn.profiler import setupLogging, Profiler
 
 '''This is a simple network in the topology of leNet5 the well-known
    MNIST dataset trainer from Yann LeCun. This is capable of training other
@@ -21,6 +21,9 @@ if __name__ == '__main__' :
                         help='Specify log output file.')
     parser.add_argument('--level', dest='level', default='INFO', type=str, 
                         help='Log Level.')
+    parser.add_argument('--prof', dest='profile', type=str, 
+                        default='Application-Profiler.xml',
+                        help='Specify profile output file.')
     parser.add_argument('--learnC', dest='learnC', type=float, default=.031,
                         help='Rate of learning on Convolutional Layers.')
     parser.add_argument('--learnF', dest='learnF', type=float, default=.015,
@@ -53,8 +56,9 @@ if __name__ == '__main__' :
     options = parser.parse_args()
 
     # setup the logger
-    log = setupLogging('cnnTrainer: ' + options.data,
-                       options.level, options.logfile)
+    logName = 'cnnTrainer: ' + options.data
+    log = setupLogging(logName, options.level, options.logfile)
+    prof = Profiler(log=log, name=logName, profFile=options.profile)
 
     # create a random number generator for efficiency
     from numpy.random import RandomState
@@ -73,19 +77,17 @@ if __name__ == '__main__' :
     network = Net(train, test, labels, regType='L2',
                   regScaleFactor=1. / (options.kernel + options.kernel + 
                                        options.neuron + len(labels)), 
-                  log=log)
+                  prof=prof)
 
     if options.synapse is not None :
         # load a previously saved network
         network.load(options.synapse)
     else :
         log.info('Initializing Network...')
-        input = t.ftensor4('input')
 
         # add convolutional layers
         network.addLayer(ConvolutionalLayer(
-            layerID='c1', input=input, 
-            inputSize=trainSize[1:],
+            layerID='c1', inputSize=trainSize[1:],
             kernelSize=(options.kernel,trainSize[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             dropout=.8 if options.dropout else 1.,
@@ -95,8 +97,7 @@ if __name__ == '__main__' :
         # this way we don't combine the channels kernels we created in 
         # the first layer and destroy our dimensionality
         network.addLayer(ConvolutionalLayer(
-            layerID='c2', input=network.getNetworkOutput(), 
-            inputSize=network.getNetworkOutputSize(), 
+            layerID='c2', inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             dropout=.5 if options.dropout else 1.,
@@ -104,15 +105,15 @@ if __name__ == '__main__' :
 
         # add fully connected layers
         network.addLayer(ContiguousLayer(
-            layerID='f3', input=network.getNetworkOutput(),
+            layerID='f3', 
             inputSize=(network.getNetworkOutputSize()[0], 
                        reduce(mul, network.getNetworkOutputSize()[1:])),
             numNeurons=options.neuron, 
             learningRate=options.learnF, momentumRate=options.momentum,
             dropout=.5 if options.dropout else 1., randomNumGen=rng))
         network.addLayer(ContiguousLayer(
-            layerID='f4', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(), numNeurons=len(labels),
+            layerID='f4', inputSize=network.getNetworkOutputSize(), 
+            numNeurons=len(labels),
             learningRate=options.learnF, momentumRate=options.momentum,
             activation=None, randomNumGen=rng))
 

--- a/trunk/apps/likenessFinder.py
+++ b/trunk/apps/likenessFinder.py
@@ -99,9 +99,9 @@ def createNetwork(image, log=None) :
             log.info('Loading Network from Disk...')
         network = ClassifierNetwork(options.synapse, log)
 
-        from nn.datasetUtils import loadShared
+        from nn.datasetUtils import toShared
         from ae.net import StackedAENetwork
-        network = StackedAENetwork((loadShared(chips, True), None), log=log)
+        network = StackedAENetwork((toShared(chips, True), None), log=log)
         network.load(options.synapse)
         for ii in range(0, chips.shape[0], 50) :
             import ae.utils
@@ -116,7 +116,7 @@ def createNetwork(image, log=None) :
     else :
         import time
         from ae.net import StackedAENetwork
-        from nn.datasetUtils import loadShared
+        from nn.datasetUtils import toShared
         from ae.convolutionalAE import ConvolutionalAutoEncoder
         from ae.contiguousAE import ContractiveAutoEncoder
         from numpy.random import RandomState
@@ -133,7 +133,7 @@ def createNetwork(image, log=None) :
             log.info('Intializing the SAE...')
 
         # create the SAE
-        network = StackedAENetwork((loadShared(chips, True), None), log=log)
+        network = StackedAENetwork((toShared(chips, True), None), log=log)
         #input = t.fmatrix('input')
         input = t.ftensor4('input')
 

--- a/trunk/apps/likenessFinder.py
+++ b/trunk/apps/likenessFinder.py
@@ -134,20 +134,16 @@ def createNetwork(image, log=None) :
 
         # create the SAE
         network = StackedAENetwork((toShared(chips, True), None), log=log)
-        #input = t.fmatrix('input')
-        input = t.ftensor4('input')
 
         # add convolutional layers
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c1', input=input,
-            inputSize=chips.shape[1:], 
+            layerID='c1', inputSize=chips.shape[1:], 
             kernelSize=(options.kernel,chips.shape[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             learningRate=options.learnC))
         '''
         network.addLayer(ConvolutionalAutoEncoder(
             layerID='c2',
-            input=network.getNetworkOutput(), 
             inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
@@ -157,30 +153,27 @@ def createNetwork(image, log=None) :
         # add fully connected layers
         numInputs = reduce(mul, network.getNetworkOutputSize()[1:])
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput(),
+            layerID='f3', 
             inputSize=(network.getNetworkOutputSize()[0], numInputs),
             numNeurons=options.hidden,
             learningRate=options.learnF, randomNumGen=rng))
         '''
 
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f1', input=input,
+            layerID='f1', 
             inputSize=(chips.shape[1], reduce(mul, chips.shape[2:])),
             numNeurons=500, learningRate=options.learnF,
             contractionRate=options.contrF, randomNumGen=rng))
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f2', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(),
+            layerID='f2', inputSize=network.getNetworkOutputSize(),
             numNeurons=200, learningRate=options.learnF,
             contractionRate=options.contrF, randomNumGen=rng))
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(),
+            layerID='f3', inputSize=network.getNetworkOutputSize(),
             numNeurons=100, learningRate=options.learnF,
             contractionRate=options.contrF, randomNumGen=rng))
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f4', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(),
+            layerID='f4', inputSize=network.getNetworkOutputSize(),
             numNeurons=50, learningRate=options.learnF,
             contractionRate=options.contrF, randomNumGen=rng))
         '''

--- a/trunk/apps/likenessFinder_FullScan.py
+++ b/trunk/apps/likenessFinder_FullScan.py
@@ -117,7 +117,7 @@ def createNetwork(image, log=None) :
     else :
         import time
         from ae.net import StackedAENetwork
-        from nn.datasetUtils import loadShared
+        from nn.datasetUtils import toShared
         from ae.convolutionalAE import ConvolutionalAutoEncoder
         from ae.contiguousAE import ContractiveAutoEncoder
         from numpy.random import RandomState
@@ -134,7 +134,7 @@ def createNetwork(image, log=None) :
             log.info('Intializing the SAE...')
 
         # create the SAE
-        network = StackedAENetwork((loadShared(chips, True), None), log=log)
+        network = StackedAENetwork((toShared(chips, True), None), log=log)
         input = t.fmatrix('input')
 
         '''

--- a/trunk/apps/likenessFinder_FullScan.py
+++ b/trunk/apps/likenessFinder_FullScan.py
@@ -135,20 +135,16 @@ def createNetwork(image, log=None) :
 
         # create the SAE
         network = StackedAENetwork((toShared(chips, True), None), log=log)
-        input = t.fmatrix('input')
 
         '''
         # add convolutional layers
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c1', input=input,
-            inputSize=chips.shape[1:], 
+            layerID='c1', inputSize=chips.shape[1:], 
             kernelSize=(options.kernel,chips.shape[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             learningRate=options.learnC))
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c2',
-            input=network.getNetworkOutput(), 
-            inputSize=network.getNetworkOutputSize(), 
+            layerID='c2', inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             learningRate=options.learnC))
@@ -156,30 +152,27 @@ def createNetwork(image, log=None) :
         # add fully connected layers
         numInputs = reduce(mul, network.getNetworkOutputSize()[1:])
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput().flatten(2),
+            layerID='f3', 
             inputSize=(network.getNetworkOutputSize()[0], numInputs),
             numNeurons=int(options.hidden*1.5),
             learningRate=options.learnF, randomNumGen=rng))
         '''
         from theano.tensor import tanh
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f1', input=input,
+            layerID='f1', 
             inputSize=(chips.shape[1], reduce(mul, chips.shape[2:])),
             numNeurons=500, learningRate=options.learnF, activation=tanh,
             contractionRate=options.contrF, randomNumGen=rng))
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f2', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(),
+            layerID='f2', inputSize=network.getNetworkOutputSize(),
             numNeurons=200, learningRate=options.learnF, activation=tanh,
             contractionRate=options.contrF, randomNumGen=rng))
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(),
+            layerID='f3', inputSize=network.getNetworkOutputSize(),
             numNeurons=100, learningRate=options.learnF, activation=tanh,
             contractionRate=options.contrF, randomNumGen=rng))
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f4', input=network.getNetworkOutput(),
-            inputSize=network.getNetworkOutputSize(),
+            layerID='f4', inputSize=network.getNetworkOutputSize(),
             numNeurons=50, learningRate=options.learnF, activation=tanh,
             contractionRate=options.contrF, randomNumGen=rng))
 

--- a/trunk/apps/semiSupervisedTrainer.py
+++ b/trunk/apps/semiSupervisedTrainer.py
@@ -89,12 +89,10 @@ if __name__ == '__main__' :
         network.load(options.synapse)
     else :
         log.info('Initializing Network...')
-        input = t.ftensor4('input')
 
         # add convolutional layers
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c1', input=input, 
-            inputSize=trainShape[1:], 
+            layerID='c1', inputSize=trainShape[1:], 
             kernelSize=(options.kernel,trainShape[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             dropout=.8 if options.dropout else 1.,
@@ -104,9 +102,7 @@ if __name__ == '__main__' :
         # this way we don't combine the channels kernels we created in 
         # the first layer and destroy our dimensionality
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c2',
-            input=network.getNetworkOutput(), 
-            inputSize=network.getNetworkOutputSize(), 
+            layerID='c2', inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             dropout=.5 if options.dropout else 1.,
@@ -114,7 +110,7 @@ if __name__ == '__main__' :
 
         # add fully connected layers
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput(),
+            layerID='f3', 
             inputSize=(network.getNetworkOutputSize()[0], 
                        reduce(mul, network.getNetworkOutputSize()[1:])),
             numNeurons=options.neuron, learningRate=options.learnF,

--- a/trunk/apps/stackedPreTrainer.py
+++ b/trunk/apps/stackedPreTrainer.py
@@ -76,12 +76,10 @@ if __name__ == '__main__' :
         network.load(options.synapse)
     else :
         log.info('Initializing Network...')
-        input = t.ftensor4('input')
 
         # add convolutional layers
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c1', input=input, 
-            inputSize=trainShape[1:], 
+            layerID='c1', inputSize=trainShape[1:], 
             kernelSize=(options.kernel,trainShape[2],5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             dropout=.8 if options.dropout else 1.,
@@ -91,9 +89,7 @@ if __name__ == '__main__' :
         # this way we don't combine the channels kernels we created in 
         # the first layer and destroy our dimensionality
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='c2',
-            input=network.getNetworkOutput(), 
-            inputSize=network.getNetworkOutputSize(), 
+            layerID='c2', inputSize=network.getNetworkOutputSize(), 
             kernelSize=(options.kernel,options.kernel,5,5),
             downsampleFactor=(2,2), randomNumGen=rng,
             dropout=.5 if options.dropout else 1., 
@@ -101,7 +97,7 @@ if __name__ == '__main__' :
 
         # add fully connected layers
         network.addLayer(ContractiveAutoEncoder(
-            layerID='f3', input=network.getNetworkOutput(),
+            layerID='f3', 
             inputSize=(network.getNetworkOutputSize()[0], 
                        reduce(mul, network.getNetworkOutputSize()[1:])),
             numNeurons=options.neuron, learningRate=options.learnF,

--- a/trunk/modules/python/dataset/ingest/unlabeled.py
+++ b/trunk/modules/python/dataset/ingest/unlabeled.py
@@ -68,7 +68,7 @@ def ingestImagery(filepath, shared=False, batchSize=1,
        return   : (trainingData, pixelRegion={None})
     '''
     import os
-    from dataset.shared import loadShared
+    from dataset.shared import toShared
     from dataset.pickle import readPickleZip
 
     # read the directory structure and chip it
@@ -81,4 +81,4 @@ def ingestImagery(filepath, shared=False, batchSize=1,
 
     # load each into shared variables -- 
     # this avoids having to copy the data to the GPU between each call
-    return loadShared(train, True, log) if shared is True else train
+    return toShared(train, True, log) if shared is True else train

--- a/trunk/modules/python/dataset/pickle.py
+++ b/trunk/modules/python/dataset/pickle.py
@@ -2,6 +2,12 @@ from six.moves import cPickle
 import gzip
 def writePickleZip (outputFile, data, log=None) :
     '''Utility to write a pickle to disk.
+
+       NOTE: This first attempts to use protocol 2 for greater portability 
+             across python versions. If that fails it, and we're using py3,
+             we attempt again with the highest protocol available. Advances in
+             py3.x allow large datasets to be pickled.
+
        outputFile : Name of the file to write. The extension should be pkl.gz
        data       : Data to write to the file
        log        : Logger to use
@@ -10,15 +16,31 @@ def writePickleZip (outputFile, data, log=None) :
         raise Exception('The file must end in the pkl.gz extension.')
     if log is not None :
         log.info('Compressing to [' + outputFile + ']')
-    with gzip.open(outputFile, 'wb') as f :
-        f.write(cPickle.dumps(data, protocol=cPickle.HIGHEST_PROTOCOL))
+
+    # attempt to pickle with protocol 2 --
+    # protocol 2 is the highest protocol supported in py2.x. If we can
+    # get away with pickling with this protocol, it will provide better
+    # portability across python releases.
+    try :
+        with gzip.open(outputFile, 'wb') as f :
+            f.write(cPickle.dumps(data, protocol=2))
+
+    # TODO: find exact error thrown while pickling large networks
+    except Exception as ex :
+        import sys
+        # large objects cannot be pickled in py2.x, so if we're using py3.x,
+        # let's attempt the pickle again with the current highest.
+        if sys.version_info >= (3, 0) :
+            with gzip.open(outputFile.replace('pkl', 'pkl3'), 'wb') as f :
+                f.write(cPickle.dumps(data, protocol=cPickle.HIGHEST_PROTOCOL))
+        else : raise ex
 
 def readPickleZip (inFile, log=None) :
     '''Utility to read a pickle in from disk.
        inFile : Name of the file to read. The extension should be pkl.gz
        log    : Logger to use
     '''
-    if not inFile.endswith('pkl.gz') :
+    if not inFile.endswith('pkl.gz') and not inFile.endswith('pkl3.gz') :
         raise Exception('The file must end in the pkl.gz extension.')
     if log is not None :
         log.info('Load the data into memory')

--- a/trunk/modules/python/dataset/shared.py
+++ b/trunk/modules/python/dataset/shared.py
@@ -1,13 +1,31 @@
 import theano as t
 
-def loadShared(x, borrow=True, log=None) :
-    '''Transfer numpy.array to theano.shared variable.
+def toShared(x, borrow=True, log=None) :
+    '''Transfer numpy.ndarry to theano.shared variable.
        NOTE: Shared variables allow for optimized GPU execution
+
+       x      : numpy.ndarray or list object to convert
+       borrow : False provides back a deep copy of the memory, True may provide
+                a shallow copy only if working on the CPU. GPU memory is always
+                deep copied back to the device.
+       log    : Logger to use
     '''
     import numpy as np
     if log is not None :
         log.debug('Wrap memory into shared variables')
     return t.shared(np.asarray(x, dtype=t.config.floatX), borrow=borrow)
+
+def fromShared(x, borrow=True, log=None) :
+    '''Transfer the memory back to a numpy.ndarry.
+       x      : Theano.shared variable to convert
+       borrow : False provides back a deep copy of the memory, True may provide
+                a shallow copy only if working on the CPU. GPU memory is always
+                deep copied back to the host.
+       log    : Logger to use
+    '''
+    if log is not None :
+        log.debug('Transfer shared memory back into numpy equivalent')
+    return x.get_value(borrow)
 
 def splitToShared(x, borrow=True, castLabelInt=True, log=None) :
     '''Create shared variables for both the input and expectedOutcome vectors.
@@ -15,13 +33,15 @@ def splitToShared(x, borrow=True, castLabelInt=True, log=None) :
                      It is assumed they are of the same length.
                      Format - (data, label)
        borrow      : Should the theano vector use the same buffer as numpy
+                     NOTE: GPU execution create new buffer regardless of the
+                           value used here.
        castLabelInt: Should the label be casted into int32
        return      : Shared Variable equivalents for these items
                      Format - (data, label)
     '''
     data, label = x
-    data = loadShared(data, borrow, log)
-    label = loadShared(label, borrow, log)
+    data = toShared(data, borrow, log)
+    label = toShared(label, borrow, log)
     if castLabelInt :
         label = t.tensor.cast(label, 'int32')
     return data, label

--- a/trunk/modules/python/nn/contiguousLayer.py
+++ b/trunk/modules/python/nn/contiguousLayer.py
@@ -82,8 +82,7 @@ class ContiguousLayer(Layer) :
         outTrain = findLogit(self.input[1], self._weights, self._thresholds)
 
         # create a convenience function
-        self.output = self.setupOutput(self._numNeurons, outClass, outTrain)
-        self.activate = function([self.input[0]], self.output[0])
+        self.output = self.setupOutput((self._numNeurons,), outClass, outTrain)
 
     def getInputSize (self) :
         '''(numInputs, pattern size)'''

--- a/trunk/modules/python/nn/convolutionalLayer.py
+++ b/trunk/modules/python/nn/convolutionalLayer.py
@@ -42,11 +42,6 @@ class ConvolutionalLayer(Layer) :
             raise ValueError('ConvolutionalLayer Error: ' +
                              'Number of Channels must match in ' +
                              'inputSize and kernelSize')
-        from theano.tensor.nnet.conv import conv2d
-        from theano.tensor.signal.downsample import max_pool_2d
-
-        # theano variables don't actually preserve buffer sizing
-        self.input = input if isinstance(input, tuple) else (input, input)
 
         self._inputSize = inputSize
         self._kernelSize = kernelSize
@@ -79,8 +74,17 @@ class ConvolutionalLayer(Layer) :
                                          dtype=config.floatX)
         self._thresholds = shared(value=initialThresholds, borrow=True)
 
-        def findLogits(input, weights, 
-                       inputSize, kernelSize, downsampleFactor, thresholds) :
+    def finalize(self, input) :
+        '''Setup the computation graph for this layer.
+           input : the input variable tuple for this layer
+                   format (inClass, inTrain)
+        '''
+        self.input = input
+        def findLogits(input, weights, inputSize, kernelSize, 
+                       downsampleFactor, thresholds) :
+            from theano.tensor.nnet.conv import conv2d
+            from theano.tensor.signal.downsample import max_pool_2d
+
             # create a function to perform the convolution
             convolve = conv2d(input, weights, inputSize, kernelSize)
 
@@ -97,34 +101,11 @@ class ConvolutionalLayer(Layer) :
                               self._inputSize, self._kernelSize,
                               self._downsampleFactor, self._thresholds)
 
-        # determine dropout if requested
-        if self._dropout is not None :
-            # here there are two possible paths --
-            # outClass : path of execution intended for classification. Here
-            #            all neurons are present and weights must be scaled by
-            #            the dropout factor. This ensures resultant 
-            #            probabilities fall within intended bounds when all
-            #            neurons are present.
-            # outTrain : path of execution for training with dropout. Here each
-            #            neuron's output goes through a Bernoulli Trial. This
-            #            retains a neuron with the probability specified by the
-            #            dropout factor.
-            outClass = outClass / self._dropout
-            outTrain = switch(self._randStream.binomial(
-                size=self.getOutputSize()[1:], p=self._dropout), outTrain, 0)
-
-        # activate the layer --
-        # output is a tuple to represent two possible paths through the
-        # computation graph. 
-        self.output = (outClass, outTrain) if activation is None else \
-                      (activation(outClass), activation(outTrain))
-
-        # we can call this method to activate the layer
+        # create a convenience function
+        self.output = self.setupOutput(self.getOutputSize()[1:], 
+                                       outClass, outTrain)
         self.activate = function([self.input[0]], self.output[0])
 
-    def getWeights(self) :
-        '''This allows the network backprop all layers efficiently.'''
-        return [self._weights, self._thresholds]
     def getInputSize (self) :
         '''The initial input size provided at construction. This is sized
            (batch size, channels, rows, columns)'''

--- a/trunk/modules/python/nn/convolutionalLayer.py
+++ b/trunk/modules/python/nn/convolutionalLayer.py
@@ -1,6 +1,6 @@
 from nn.layer import Layer
 import numpy as np
-from theano.tensor import tanh, switch
+from theano.tensor import tanh
 from theano import shared, config, function
 
 class ConvolutionalLayer(Layer) :
@@ -8,7 +8,6 @@ class ConvolutionalLayer(Layer) :
        a series of kernels and subsample.
 
        layerID           : unique name identifier for this layer
-       input             : the input buffer for this layer
        inputSize         : (batch size, channels, rows, columns)
        kernelSize        : (number of kernels, channels, rows, columns)
        downsampleFactor  : (rowFactor, columnFactor)
@@ -28,11 +27,12 @@ class ConvolutionalLayer(Layer) :
        randomNumGen      : generator for the initial weight values - 
                            type is numpy.random.RandomState
     '''
-    def __init__ (self, layerID, input, inputSize, kernelSize, 
+    def __init__ (self, layerID, inputSize, kernelSize, 
                   downsampleFactor, learningRate=0.001, momentumRate=0.9,
                   dropout=None, initialWeights=None, initialThresholds=None,
                   activation=tanh, randomNumGen=None) :
-        Layer.__init__(self, layerID, learningRate, momentumRate, dropout)
+        Layer.__init__(self, layerID, learningRate, momentumRate, dropout,
+                       activation)
 
         # TODO: this check is likely unnecessary
         if inputSize[2] == kernelSize[2] or inputSize[3] == kernelSize[3] :
@@ -104,7 +104,6 @@ class ConvolutionalLayer(Layer) :
         # create a convenience function
         self.output = self.setupOutput(self.getOutputSize()[1:], 
                                        outClass, outTrain)
-        self.activate = function([self.input[0]], self.output[0])
 
     def getInputSize (self) :
         '''The initial input size provided at construction. This is sized

--- a/trunk/modules/python/nn/layer.py
+++ b/trunk/modules/python/nn/layer.py
@@ -6,7 +6,7 @@ class Layer () :
     _randStream = RandomStreams(int(time()))
 
     def __init__ (self, layerID, learningRate=0.001, 
-                  momentumRate=0.9, dropout=None) :
+                  momentumRate=0.9, dropout=None, activation=None) :
         '''This class describes an abstract Neural Layer.
            layerID      : unique name identifier for this layer
            learningRate : multiplier for speed of gradient descent 
@@ -18,12 +18,63 @@ class Layer () :
         # output must be a tuple
         self.output = None
         self.layerID = layerID
+        self._weights = None
+        self._thresholds = None
         self._learningRate = learningRate
         self._momentumRate = momentumRate
         self._dropout = dropout
+        self._activation = activation
+
+    def __getstate__(self) :
+        '''Save layer pickle'''
+        from dataset.shared import fromShared
+        dict = self.__dict__.copy()
+        dict['input'] = None
+        dict['output'] = None
+        dict['_weights'] = fromShared(self._weights)
+        dict['_thresholds'] = fromShared(self._thresholds)
+        return dict
+
+    def __setstate__(self, dict) :
+        '''Load layer pickle'''
+        from theano import shared
+        self.__dict__.update(dict)
+        initialWeights = self._weights
+        self._weights = shared(value=initialWeights, borrow=True)
+        initialThresholds = self._thresholds
+        self._thresholds = shared(value=initialThresholds, borrow=True)
+
+    def setupOutput(self, numNeurons, outClass, outTrain) :
+        from theano.tensor import switch
+
+        # determine dropout if requested
+        if self._dropout is not None :
+            # here there are two possible paths --
+            # outClass : path of execution intended for classification. Here
+            #            all neurons are present and weights must be scaled by
+            #            the dropout factor. This ensures resultant 
+            #            probabilities fall within intended bounds when all
+            #            neurons are present.
+            # outTrain : path of execution for training with dropout. Here each
+            #            neuron's output goes through a Bernoulli Trial. This
+            #            retains a neuron with the probability specified by the
+            #            dropout factor.
+            outClass = outClass / self._dropout
+            outTrain = switch(self._randStream.binomial(
+                size=(numNeurons,), p=self._dropout), outTrain, 0)
+
+        # activate the layer --
+        # output is a tuple to represent two possible paths through the
+        # computation graph. 
+        return (outClass, outTrain) if self._activation is None else \
+               (self._activation(outClass), self._activation(outTrain))
+
+    def finalize(self) :
+        raise NotImplementedError('Implement the finalize() method')
 
     def getWeights(self) :
-        raise NotImplementedError('Implement the getWeights() method')
+        '''This allows the network backprop all layers efficiently.'''
+        return [self._weights, self._thresholds]
 
     def getMomentumRate(self) :
         return self._momentumRate

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -1,5 +1,4 @@
 from nn.layer import Layer
-from nn.profiler import Profiler
 import theano.tensor as t
 import theano
 import numpy as np
@@ -306,6 +305,12 @@ class TrainerNetwork (ClassifierNetwork) :
                              'to call getNetworkInput().')
 
         self._startProfile('Finalizing Network', 'info')
+
+        # finalize the layers to create the computational graphs
+        layerInput = (self._trainData, self._trainData)
+        for layer in self._layers :
+            layer.finalize(layerInput)
+            layerInput = layer.output
 
         # disable the profiler temporarily so we don't get a second entry
         tmp = self._profiler

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -6,10 +6,8 @@ import numpy as np
 from dataset.pickle import writePickleZip, readPickleZip
 
 class Network () :
-    def __init__ (self, log=None) :
-        self._profiler = Profiler(log, 'NeuralNet', 
-                                  './NeuralNet-Profile.xml') if \
-                                  log is not None else None
+    def __init__ (self, prof=None) :
+        self._profiler = prof
         self._layers = []
     def __getstate__(self) :
         '''Save network pickle'''
@@ -87,10 +85,10 @@ class ClassifierNetwork (Network) :
 
        filepath : Path to an already trained network on disk 
                   'None' creates randomized weighting
-       log      : Logger to use
+       prof     : Profiler to use
     '''
-    def __init__ (self, filepath=None, log=None) :
-        Network.__init__(self, log)
+    def __init__ (self, filepath=None, prof=None) :
+        Network.__init__(self, prof)
         self._networkLabels = []
         if filepath is not None :
             self.load(filepath)
@@ -246,11 +244,11 @@ class TrainerNetwork (ClassifierNetwork) :
                   NOTE: a good value is 1. / numTotalNeurons
        filepath : Path to an already trained network on disk 
                   'None' creates randomized weighting
-       log      : Logger to use
+       prof     : Profiler to use
     '''
     def __init__ (self, train, test, labels, regType='L2', regScaleFactor=0.,
-                  filepath=None, log=None) :
-        ClassifierNetwork.__init__(self, filepath=filepath, log=log)
+                  filepath=None, prof=None) :
+        ClassifierNetwork.__init__(self, filepath=filepath, prof=prof)
         if filepath is None :
             self._networkLabels = labels
         self._trainData, self._trainLabels = train
@@ -429,7 +427,7 @@ class TrainerNetwork (ClassifierNetwork) :
             # DEBUG: For Debugging purposes only 
             #for layer in self._layers :
             #    layer.writeWeights(globalEpoch + localEpoch)
-            self._startProfile('Running Epoch [' + 
+            self._startProfile('Running Epoch [' +
                                str(globalEpoch + localEpoch) + ']', 'info')
             [self.train(ii) for ii in range(self._numTrainBatches)]
             self._endProfile()
@@ -451,147 +449,3 @@ class TrainerNetwork (ClassifierNetwork) :
 
         self._endProfile()
         return acc / float(self._numTestSize) * 100.
-
-if __name__ == "__main__" :
-    labels = t.ivector("lables")
-    outputSize = t.iscalar("outputSize")
-    def createExpectedOutput(label, outputSize):
-        return t.set_subtensor(
-            t.zeros((outputSize,), dtype='float32')[label], 1.)
-    result, updates = theano.scan(fn=createExpectedOutput,
-                                  outputs_info=None,
-                                  sequences=[labels],
-                                  non_sequences=[outputSize])
-    createBatchExpectedOutput = theano.function(
-        inputs=[labels, outputSize], outputs=result)
-
-    # test
-    import numpy
-    labelVect = numpy.asarray([1, 2, 0], dtype=numpy.int32)
-    print(createBatchExpectedOutput(labelVect, 5))
-
-    '''
-    location = t.ivector("location")
-    output_model = t.fvector("output_model")
-    def set_value_at_position(a_location, output_model):
-        return t.set_subtensor(t.zeros_like(output_model)[a_location], 1.)
-    result, updates = theano.scan(fn=set_value_at_position,
-                                  outputs_info=None,
-                                  sequences=[location],
-                                  non_sequences=[output_model])
-    assign_values_at_positions = theano.function(
-        inputs=[location, output_model], 
-        outputs=result)
-
-    # test
-    import numpy
-    test_locations = numpy.asarray([1, 2, 0], dtype=numpy.int32)
-    test_output_model = numpy.zeros((5,), dtype=numpy.float32)
-    print(assign_values_at_positions(test_locations, test_output_model))
-    
-    import numpy as np
-    value = t.fscalar('value')
-    expectedLabels = t.ivector('expectedLabels')
-    expectedOutputs = theano.shared(np.zeros((5,5), dtype='float32'), 
-                                    name='expectedOutputs')
-#    expectedOutputs = theano.shared(value=np.zeros((5,5), dtype='int32'), 
-#                                    name='expectedOutputs')
-    def updateVector(vect, indx, value) :
-        print vect.type
-        print indx.type
-        print value.type
-        return t.set_subtensor(vect[indx], value)
-    results, updates = theano.scan(
-        fn=updateVector,
-        outputs_info=None,
-        sequences=[expectedOutputs, expectedLabels],
-        non_sequences=value)
-
-
-    indx = t.iscalar('indx')
-    updateExpectedMatrix = theano.function(
-        [expectedLabels, value], results[-1])
-
-    labels = np.asarray([1,0,3,4,5], dtype='int32')
-    updateExpectedMatrix(labels, 1.)
-    print expectedOutputs.type
-
-    print expectedOutputs.type
-    theano.function([expectedOutputs], )
-    print dir(t.set_subtensor(expectedOutputs[0], 1.))
-    print expectedOutputs.get_value()
-
-
-    # this shows the execution of a sequence of functions by
-    # combining them into a higher level function
-    a = t.iscalar('a')
-    b = t.iscalar('b')
-
-    out1 = a**2
-    square = theano.function([a], out1)
-
-    out2 = out1**3
-    cube = theano.function([out1], out2)
-
-    total = theano.function([a], out2)
-
-    print square(4)
-    print cube(4)
-    print total(4)
-
-    from contiguousLayer import ContiguousLayer
-    from time import time
-    from datasetUtils import splitToShared
-    import numpy
-
-    input = t.fmatrix('input')
-
-    dim = 1000
-    numNeurons = 10
-    numRuns = 10000
-
-    # this is intentionally getting one of the inputs labels incorrect to
-    # prove the checkAccuracy call is working.
-    trainArr = (numpy.asarray([[range(dim)]], dtype='float32'), 
-                numpy.asarray([[0]], dtype='int32'))
-    testArr  = (numpy.asarray([[range(dim), range(dim), range(dim)]], dtype='float32'), 
-                numpy.asarray([[1, 2, 1]], dtype='int32'))
-
-    print testArr[0].shape
-    print testArr[1].shape
-    train = splitToShared(trainArr, borrow=True)
-    test  = splitToShared(testArr,  borrow=True)
-
-    network = TrainerNetwork(train, test, regType='')
-    network.addLayer(
-        ContiguousLayer('f1', input, dim, numNeurons))
-    network.addLayer(
-        ContiguousLayer('f2', network.getNetworkOutput(), numNeurons, 3))
-
-    print "Classify: " + str(network.classify(testArr[0][0]))
-    print "NLL: " + str(network.check(testArr[0][0], testArr[1][0]))
-
-    # test the classify runtime
-    print "Classifying Inputs..."
-    timer = time()
-    for i in range(numRuns) :
-        out = network.classify(trainArr[0][0])
-    timer = time() - timer
-    print "total time: " + str(timer) + \
-          "s | per input: " + str(timer/numRuns) + "s"
-    print network.classify(testArr[0][0])
-
-    # test the train runtime
-    numRuns = 10000
-    print "Training Network..."
-    timer = time()
-    for ii in range(numRuns) :
-        network.train(0)
-#    network.trainEpoch(0, numRuns)
-    timer = time() - timer
-    print "total time: " + str(timer) + \
-          "s | per input: " + str(timer/numRuns) + "s"
-    print str(network.checkAccuracy() * 100.)
-
-    network.save('e:/out.pkl.gz')
-    '''

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -1,5 +1,4 @@
 from nn.layer import Layer
-from nn.profiler import Profiler
 import theano.tensor as t
 import theano
 import numpy as np
@@ -326,6 +325,12 @@ class TrainerNetwork (ClassifierNetwork) :
                              'to call getNetworkInput().')
 
         self._startProfile('Finalizing Network', 'info')
+
+        # finalize the layers to create the computational graphs
+        layerInput = (self._trainData, self._trainData)
+        for layer in self._layers :
+            layer.finalize(layerInput)
+            layerInput = layer.output
 
         # disable the profiler temporarily so we don't get a second entry
         tmp = self._profiler

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -6,10 +6,8 @@ import numpy as np
 from dataset.pickle import writePickleZip, readPickleZip
 
 class Network () :
-    def __init__ (self, log=None) :
-        self._profiler = Profiler(log, 'NeuralNet', 
-                                  './NeuralNet-Profile.xml') if \
-                                  log is not None else None
+    def __init__ (self, prof=None) :
+        self._profiler = prof
         self._layers = []
     def __getstate__(self) :
         '''Save network pickle'''
@@ -87,10 +85,10 @@ class ClassifierNetwork (Network) :
 
        filepath : Path to an already trained network on disk 
                   'None' creates randomized weighting
-       log      : Logger to use
+       prof     : Profiler to use
     '''
-    def __init__ (self, filepath=None, log=None) :
-        Network.__init__(self, log)
+    def __init__ (self, filepath=None, prof=None) :
+        Network.__init__(self, prof)
         self._networkLabels = []
         if filepath is not None :
             self.load(filepath)
@@ -246,11 +244,11 @@ class TrainerNetwork (ClassifierNetwork) :
                   NOTE: a good value is 1. / numTotalNeurons
        filepath : Path to an already trained network on disk 
                   'None' creates randomized weighting
-       log      : Logger to use
+       prof     : Profiler to use
     '''
     def __init__ (self, train, test, labels, regType='L2', regScaleFactor=0.,
-                  filepath=None, log=None) :
-        ClassifierNetwork.__init__(self, filepath=filepath, log=log)
+                  filepath=None, prof=None) :
+        ClassifierNetwork.__init__(self, filepath=filepath, prof=prof)
         if filepath is None :
             self._networkLabels = labels
         self._trainData, self._trainLabels = train
@@ -475,7 +473,7 @@ class TrainerNetwork (ClassifierNetwork) :
             # DEBUG: For Debugging purposes only 
             #for layer in self._layers :
             #    layer.writeWeights(globalEpoch + localEpoch)
-            self._startProfile('Running Epoch [' + 
+            self._startProfile('Running Epoch [' +
                                str(globalEpoch + localEpoch) + ']', 'info')
             for ii in range(self._numTrainBatches) :
                 self.train(ii, self._trainData[ii], self._trainLabels[ii])
@@ -498,147 +496,3 @@ class TrainerNetwork (ClassifierNetwork) :
 
         self._endProfile()
         return acc / float(self._numTestSize) * 100.
-
-if __name__ == "__main__" :
-    labels = t.ivector("lables")
-    outputSize = t.iscalar("outputSize")
-    def createExpectedOutput(label, outputSize):
-        return t.set_subtensor(
-            t.zeros((outputSize,), dtype='float32')[label], 1.)
-    result, updates = theano.scan(fn=createExpectedOutput,
-                                  outputs_info=None,
-                                  sequences=[labels],
-                                  non_sequences=[outputSize])
-    createBatchExpectedOutput = theano.function(
-        inputs=[labels, outputSize], outputs=result)
-
-    # test
-    import numpy
-    labelVect = numpy.asarray([1, 2, 0], dtype=numpy.int32)
-    print(createBatchExpectedOutput(labelVect, 5))
-
-    '''
-    location = t.ivector("location")
-    output_model = t.fvector("output_model")
-    def set_value_at_position(a_location, output_model):
-        return t.set_subtensor(t.zeros_like(output_model)[a_location], 1.)
-    result, updates = theano.scan(fn=set_value_at_position,
-                                  outputs_info=None,
-                                  sequences=[location],
-                                  non_sequences=[output_model])
-    assign_values_at_positions = theano.function(
-        inputs=[location, output_model], 
-        outputs=result)
-
-    # test
-    import numpy
-    test_locations = numpy.asarray([1, 2, 0], dtype=numpy.int32)
-    test_output_model = numpy.zeros((5,), dtype=numpy.float32)
-    print(assign_values_at_positions(test_locations, test_output_model))
-    
-    import numpy as np
-    value = t.fscalar('value')
-    expectedLabels = t.ivector('expectedLabels')
-    expectedOutputs = theano.shared(np.zeros((5,5), dtype='float32'), 
-                                    name='expectedOutputs')
-#    expectedOutputs = theano.shared(value=np.zeros((5,5), dtype='int32'), 
-#                                    name='expectedOutputs')
-    def updateVector(vect, indx, value) :
-        print vect.type
-        print indx.type
-        print value.type
-        return t.set_subtensor(vect[indx], value)
-    results, updates = theano.scan(
-        fn=updateVector,
-        outputs_info=None,
-        sequences=[expectedOutputs, expectedLabels],
-        non_sequences=value)
-
-
-    indx = t.iscalar('indx')
-    updateExpectedMatrix = theano.function(
-        [expectedLabels, value], results[-1])
-
-    labels = np.asarray([1,0,3,4,5], dtype='int32')
-    updateExpectedMatrix(labels, 1.)
-    print expectedOutputs.type
-
-    print expectedOutputs.type
-    theano.function([expectedOutputs], )
-    print dir(t.set_subtensor(expectedOutputs[0], 1.))
-    print expectedOutputs.get_value()
-
-
-    # this shows the execution of a sequence of functions by
-    # combining them into a higher level function
-    a = t.iscalar('a')
-    b = t.iscalar('b')
-
-    out1 = a**2
-    square = theano.function([a], out1)
-
-    out2 = out1**3
-    cube = theano.function([out1], out2)
-
-    total = theano.function([a], out2)
-
-    print square(4)
-    print cube(4)
-    print total(4)
-
-    from contiguousLayer import ContiguousLayer
-    from time import time
-    from datasetUtils import splitToShared
-    import numpy
-
-    input = t.fmatrix('input')
-
-    dim = 1000
-    numNeurons = 10
-    numRuns = 10000
-
-    # this is intentionally getting one of the inputs labels incorrect to
-    # prove the checkAccuracy call is working.
-    trainArr = (numpy.asarray([[range(dim)]], dtype='float32'), 
-                numpy.asarray([[0]], dtype='int32'))
-    testArr  = (numpy.asarray([[range(dim), range(dim), range(dim)]], dtype='float32'), 
-                numpy.asarray([[1, 2, 1]], dtype='int32'))
-
-    print testArr[0].shape
-    print testArr[1].shape
-    train = splitToShared(trainArr, borrow=True)
-    test  = splitToShared(testArr,  borrow=True)
-
-    network = TrainerNetwork(train, test, regType='')
-    network.addLayer(
-        ContiguousLayer('f1', input, dim, numNeurons))
-    network.addLayer(
-        ContiguousLayer('f2', network.getNetworkOutput(), numNeurons, 3))
-
-    print "Classify: " + str(network.classify(testArr[0][0]))
-    print "NLL: " + str(network.check(testArr[0][0], testArr[1][0]))
-
-    # test the classify runtime
-    print "Classifying Inputs..."
-    timer = time()
-    for i in range(numRuns) :
-        out = network.classify(trainArr[0][0])
-    timer = time() - timer
-    print "total time: " + str(timer) + \
-          "s | per input: " + str(timer/numRuns) + "s"
-    print network.classify(testArr[0][0])
-
-    # test the train runtime
-    numRuns = 10000
-    print "Training Network..."
-    timer = time()
-    for ii in range(numRuns) :
-        network.train(0)
-#    network.trainEpoch(0, numRuns)
-    timer = time() - timer
-    print "total time: " + str(timer) + \
-          "s | per input: " + str(timer/numRuns) + "s"
-    print str(network.checkAccuracy() * 100.)
-
-    network.save('e:/out.pkl.gz')
-    '''

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -275,9 +275,6 @@ class TrainerNetwork (ClassifierNetwork) :
         if '_regularization' in dict : del dict['_regularization']
         # remove the functions -- they will be rebuilt JIT
         if '_checkAccuracy' in dict : del dict['_checkAccuracy']
-        if '_createBatchExpectedOutput' in dict :
-            del dict['_createBatchExpectedOutput']
-        if '_cost' in dict : del dict['_cost']
         if '_trainNetwork' in dict : del dict['_trainNetwork']
         return dict
 
@@ -285,11 +282,7 @@ class TrainerNetwork (ClassifierNetwork) :
         '''Load network pickle'''
         # remove any current functions from the object so we force the
         # theano functions to be rebuilt with the new buffers
-        if hasattr(self, '_checkAccuracy') :
-            delattr(self, '_checkAccuracy')
-        if hasattr(self, '_createBatchExpectedOutput') :
-            delattr(self, '_createBatchExpectedOutput')
-        if hasattr(self, '_cost') : delattr(self, '_cost')
+        if hasattr(self, '_checkAccuracy') : delattr(self, '_checkAccuracy')
         if hasattr(self, '_trainNetwork') : delattr(self, '_trainNetwork')
         ClassifierNetwork.__setstate__(self, dict)
 
@@ -307,10 +300,14 @@ class TrainerNetwork (ClassifierNetwork) :
         self._startProfile('Finalizing Network', 'info')
 
         # finalize the layers to create the computational graphs
-        layerInput = (self._trainData, self._trainData)
+        layerInput = (self._trainData[0], self._trainData[0])
         for layer in self._layers :
+            self._startProfile('Finalizing Layer [' + layer.layerID + ']', 
+                               'debug')
             layer.finalize(layerInput)
             layerInput = layer.output
+            self._endProfile()
+
 
         # disable the profiler temporarily so we don't get a second entry
         tmp = self._profiler

--- a/trunk/modules/python/nn/opMap.py
+++ b/trunk/modules/python/nn/opMap.py
@@ -1,0 +1,23 @@
+
+def convertActivation(op) :
+    '''This operation converts theano activation function to and from string
+       format. This is used for improved pickle compression.
+    '''
+    import theano
+    if op is None :
+        return op
+
+    # create a map to perform the conversion
+    opMap = {'tanh' : theano.tensor.tanh, 
+             'sigmoid' : theano.tensor.nnet.sigmoid}
+
+    # attempt to perform the lookup
+    if op in opMap.keys() :
+        return opMap[op]
+
+    # inverse the map and attempt the lookup again
+    invOpMap = {v: k for k, v in opMap.items()}
+    if op in invOpMap.keys() :
+        return invOpMap[op]
+
+    raise ValueError('Operation [' + op + '] is not supported.')

--- a/trunk/modules/python/nn/trainUtils.py
+++ b/trunk/modules/python/nn/trainUtils.py
@@ -28,7 +28,7 @@ def trainUnsupervised(network, appName, dataPath, numEpochs=5, stop=30,
     # train each layer in sequence --
     # first we pre-train the data and at each epoch, we save it to disk
     lastSave = ''
-    globalEpoch = 0
+    globalEpoch = resumeEpoch(synapse)
     for layerIndex in range(network.getNumLayers()) :
         globalEpoch, cost = network.trainEpoch(layerIndex, globalEpoch, 
                                                numEpochs)
@@ -62,7 +62,7 @@ def trainSupervised (network, appName, dataPath, numEpochs=5, stop=30,
 
     degradationCount = 0
     globalCount = lastBest = resumeEpoch(synapse)
-    runningAccuracy = 0.0
+    runningAccuracy = network.checkAccuracy()
     lastSave = ''
     while True :
         timer = time()

--- a/trunk/projects/distillery/shallowNet.py
+++ b/trunk/projects/distillery/shallowNet.py
@@ -15,8 +15,6 @@ def createNetwork(inputSize, numKernels, numNeurons, numLabels) :
     from operator import mul
     rng = RandomState(int(time()))
 
-    input = t.ftensor4('input')
-
     trainSize = inputSize
 
     # create the network
@@ -24,22 +22,21 @@ def createNetwork(inputSize, numKernels, numNeurons, numLabels) :
 
     # add convolutional layers
     network.addLayer(ConvolutionalLayer(
-        layerID='c1', input=input, 
-        inputSize=trainSize,
+        layerID='c1', inputSize=trainSize,
         kernelSize=(numKernels,trainSize[1],3,3),
         downsampleFactor=(3,3), randomNumGen=rng,
         learningRate=.08, momentumRate=.1))
     # add fully connected layers
     network.addLayer(ContiguousLayer(
-        layerID='f2', input=network.getNetworkOutput(),
+        layerID='f2', 
         inputSize=(network.getNetworkOutputSize()[0],
                    reduce(mul, network.getNetworkOutputSize()[1:])),
         numNeurons=numNeurons, randomNumGen=rng,
         learningRate=.025, momentumRate=.2))
     network.addLayer(ContiguousLayer(
-        layerID='f3', input=network.getNetworkOutput(),
-        inputSize=network.getNetworkOutputSize(), numNeurons=numLabels,
-        learningRate=.015, momentumRate=.3, activation=None, randomNumGen=rng))
+        layerID='f3', inputSize=network.getNetworkOutputSize(), 
+        numNeurons=numLabels, learningRate=.015, momentumRate=.3, 
+        activation=None, randomNumGen=rng))
 
     return network
     

--- a/trunk/projects/unsupervised/multiInputRandomTrainer.py
+++ b/trunk/projects/unsupervised/multiInputRandomTrainer.py
@@ -29,32 +29,28 @@ def buildStackedAENetwork(train,
     # prepare for the next layer
     def prepare(network, count) :
         return (count + 1, 
-                network.getNetworkOutput(), 
                 network.getNetworkOutputSize())
 
     layerCount = 1
-    layerInput = t.ftensor4('input')
     layerInputSize = train.eval().shape[1:]
     for k,ks,do,l,m,dr in zip(kernelConv, kernelSizeConv, downsampleConv, 
                               learnConv, momentumConv, dropoutConv) :
         # add a convolutional layer as defined
         network.addLayer(ConvolutionalAutoEncoder(
-            layerID='conv' + str(layerCount), input=layerInput, 
+            layerID='conv' + str(layerCount), 
             inputSize=layerInputSize, kernelSize=(k,layerInputSize[1],ks,ks),
             downsampleFactor=[do,do], dropout=dr, learningRate=l,
             randomNumGen=rng))
 
         # prepare for the next layer
-        layerCount, layerInput, layerInputSize = prepare(network, layerCount)
+        layerCount, layerInputSize = prepare(network, layerCount)
 
     # update to transition for fully connected layers
     layerInputSize = (layerInputSize[0], reduce(mul, layerInputSize[1:]))
-    layerInput = t.reshape(layerInput, layerInputSize)
-
     for n,l,m,dr in zip(neuronFull, learnFull, momentumFull, dropoutFull) :
         # add a fully-connected layer as defined
         network.addLayer(ContractiveAutoEncoder(
-            layerID='fully' + str(layerCount), input=layerInput,
+            layerID='fully' + str(layerCount), 
             inputSize=layerInputSize, numNeurons=n, learningRate=l,
             dropout=dr, randomNumGen=rng))            
 


### PR DESCRIPTION
Pickles now are based on numpy to support training and deployment on different architectures. All Theano breadcrumbs are removed from the pickles as well. Layers now finalize JIT, just as was performed in net to facilitate these new updates and simplify the construction.

Pickling now attempts protocol 2 for better synapse support between py3 and py2. If the pickle fails (large networks will fail) and the user is using py3, the highest protocol will be used to get 64bit support. 

fixing a minor bug in the resume from synapse logic to always start running accuracy from initialized network accuracy. I noticed cases this was performing poorly if the next checkAccuracy() was less than previous best before synapse was used. 

The profiler is now passed to the network to better support multi-network setups and transfer learning.

All apps are now updated to the simpler network construction.
