### PR TITLE
Pad dimensions

### DIFF
--- a/trunk/modules/python/dataset/ingest/labeled.py
+++ b/trunk/modules/python/dataset/ingest/labeled.py
@@ -241,6 +241,8 @@ def hdf5Dataset(filepath, holdoutPercentage=.05, minTest=5,
                       sampleSize=50)
     sizedFile = next((t[0] for t in train if os.path.getsize(t[0]) == size))
     imageShape = list(getImageDims(sizedFile, log))
+    if len(imageShape) == 2:  # pad out single channel data
+        imageShape = [1] + imageShape
 
     trainShape = [len(train) // batchSize, batchSize] + imageShape
     # TODO: performs a floor, so if there is less than one batch no

--- a/trunk/modules/python/dataset/ingest/labeled.py
+++ b/trunk/modules/python/dataset/ingest/labeled.py
@@ -241,8 +241,6 @@ def hdf5Dataset(filepath, holdoutPercentage=.05, minTest=5,
                       sampleSize=50)
     sizedFile = next((t[0] for t in train if os.path.getsize(t[0]) == size))
     imageShape = list(getImageDims(sizedFile, log))
-    if len(imageShape) == 2:  # pad out single channel data
-        imageShape = [1] + imageShape
 
     trainShape = [len(train) // batchSize, batchSize] + imageShape
     # TODO: performs a floor, so if there is less than one batch no

--- a/trunk/modules/python/dataset/reader.py
+++ b/trunk/modules/python/dataset/reader.py
@@ -22,16 +22,15 @@ def mostCommonExt(files, samplesize=None) :
 
 def atleastND(imgData, nd) :
     '''Convert input to an n-d numpy array'''
-    # I'd like to use numpy.atleast_3d but it puts
-    # the singleton dimensions before and after the input
-    # while we want them before it
+    # NOTE: np.atleast_3d does not provide enough control,
+    # so this is performed manually.
     while len(imgData.shape) < nd:
         imgData = np.expand_dims(imgData, axis=0)
     return imgData
 
 def padImageData(imgData, dims) :
     '''Add zeropadding to an image to achieve the target dimensions.'''
-    if (imgData.shape != tuple(dims)) :
+    if imgData.shape != tuple(dims) :
         pads = tuple([(0, a - b) for a, b in zip(dims, imgData.shape)])
         imgData = np.pad(imgData, pads, mode='constant', constant_values=0)
     return imgData

--- a/trunk/modules/python/dataset/reader.py
+++ b/trunk/modules/python/dataset/reader.py
@@ -22,6 +22,13 @@ def mostCommonExt(files, samplesize=None) :
 
 def padImageData(imgData, dims) :
     '''Add zeropadding to an image to achieve the target dimensions.'''
+    if type(dims) != tuple :
+        dims = tuple(dims)
+
+    # add an extra singleton dimension for 1-channel arrays
+    if len(imgData.shape) == (len(dims) - 1) :
+        imgData = np.expand_dims(imgData, axis=0)
+
     if (imgData.shape != dims) :
         pads = tuple([(0, a - b) for a, b in zip(dims, imgData.shape)])
         imgData = np.pad(imgData, pads, mode='constant', constant_values=0)

--- a/trunk/modules/python/dataset/reader.py
+++ b/trunk/modules/python/dataset/reader.py
@@ -20,12 +20,12 @@ def mostCommonExt(files, samplesize=None) :
     '''Returns the most common extension in the set of names.'''
     return mostCommon(files, lambda f: os.path.splitext(f)[1], samplesize)
 
-def atleast3D(imgData) :
-    '''Convert input to a 3d numpy array'''
+def atleastND(imgData, nd) :
+    '''Convert input to an n-d numpy array'''
     # I'd like to use numpy.atleast_3d but it puts
     # the singleton dimensions before and after the input
     # while we want them before it
-    while len(imgData.shape) < 3:
+    while len(imgData.shape) < nd:
         imgData = np.expand_dims(imgData, axis=0)
     return imgData
 
@@ -179,7 +179,7 @@ def readImage(image, log=None) :
     else :
         ret = readPILImage(image, log)
 
-    return atleast3D(ret)
+    return atleastND(ret, 3)
 
 def getImageDims(image, log=None) :
     '''Load the image and return its dimensions.

--- a/trunk/modules/python/dataset/reader.py
+++ b/trunk/modules/python/dataset/reader.py
@@ -31,10 +31,7 @@ def atleastND(imgData, nd) :
 
 def padImageData(imgData, dims) :
     '''Add zeropadding to an image to achieve the target dimensions.'''
-    if type(dims) != tuple :
-        dims = tuple(dims)
-
-    if (imgData.shape != dims) :
+    if (imgData.shape != tuple(dims)) :
         pads = tuple([(0, a - b) for a, b in zip(dims, imgData.shape)])
         imgData = np.pad(imgData, pads, mode='constant', constant_values=0)
     return imgData

--- a/trunk/modules/python/dataset/reader.py
+++ b/trunk/modules/python/dataset/reader.py
@@ -20,14 +20,19 @@ def mostCommonExt(files, samplesize=None) :
     '''Returns the most common extension in the set of names.'''
     return mostCommon(files, lambda f: os.path.splitext(f)[1], samplesize)
 
+def atleast3D(imgData) :
+    '''Convert input to a 3d numpy array'''
+    # I'd like to use numpy.atleast_3d but it puts
+    # the singleton dimensions before and after the input
+    # while we want them before it
+    while len(imgData.shape) < 3:
+        imgData = np.expand_dims(imgData, axis=0)
+    return imgData
+
 def padImageData(imgData, dims) :
     '''Add zeropadding to an image to achieve the target dimensions.'''
     if type(dims) != tuple :
         dims = tuple(dims)
-
-    # add an extra singleton dimension for 1-channel arrays
-    if len(imgData.shape) == (len(dims) - 1) :
-        imgData = np.expand_dims(imgData, axis=0)
 
     if (imgData.shape != dims) :
         pads = tuple([(0, a - b) for a, b in zip(dims, imgData.shape)])
@@ -162,16 +167,19 @@ def readImage(image, log=None) :
     #       for image types. Change this in the future to a try/catch and 
     #       allow the library decide what it is (or pass in a parameter for
     #       optimized performance).
+    ret = None
     if imageLower.endswith('.sio') :
-        return readSIO(image, log)
+        ret = readSIO(image, log)
     elif 'sicd' in imageLower :
-        return readSICD(image, log)
+        ret = readSICD(image, log)
     elif 'sidd' in imageLower :
-        return readSIDD(image, log)
+        ret = readSIDD(image, log)
     elif imageLower.endswith('.nitf') or imageLower.endswith('.ntf') :
-        return readNITF(image, log)
+        ret = readNITF(image, log)
     else :
-        return readPILImage(image, log)
+        ret = readPILImage(image, log)
+
+    return atleast3D(ret)
 
 def getImageDims(image, log=None) :
     '''Load the image and return its dimensions.


### PR DESCRIPTION
Adding the tweaks below let fixed the problem with the script crashing;
h5ls gives the dimensions we would expect for the output datasets:
/                           Group
/labels                  Dataset {1}
/test                     Group
/test/data             Dataset {5, 200, 1, 64, 64}
/test/indices          Dataset {5, 200}
/train                    Group
/train/data            Dataset {20, 200, 1, 64, 64}
/train/indices         Dataset {20, 200}
