### PR TITLE
updates to allows None for batchSize, so it can change between training and deployment. 

### DIFF
--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -150,8 +150,8 @@ class ContiguousAutoEncoder(ContiguousLayer, AutoEncoder) :
             self._costs.append(leastSquares(
                 computeJacobian(self.output[0], self._weights,
                                 self._inputSize[0], self._inputSize[1],
-                                self._numNeurons), 
-                self._inputSize[0], self._contractionRate))
+                                self._numNeurons),
+                self._contractionRate))
             self._costLabels.append('Jacob')
 
         # create the negative log likelihood function --
@@ -166,8 +166,7 @@ class ContiguousAutoEncoder(ContiguousLayer, AutoEncoder) :
             self._costs.append(regularization)
             self._costLabels.append('Regularization')
 
-        gradients = t.grad(t.sum(self._costs) / self.getInputSize()[0],
-                           self.getWeights())
+        gradients = t.grad(t.sum(self._costs), self.getWeights())
         self._updates = compileUpdate(self.getWeights(), gradients,
                                       self._learningRate, self._momentumRate)
 

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -345,8 +345,7 @@ class TrainerSAENetwork (SAENetwork) :
             # in additional to the existing costs.
             costs.append(calcLoss(netInput, decodedInput,
                                   self._layers[0].getActivation()))
-            gradients = t.grad(t.sum(costs) / self.getNetworkInputSize()[0],
-                               encoder.getWeights())
+            gradients = t.grad(t.sum(costs), encoder.getWeights())
             updates = compileUpdate(encoder.getWeights(), gradients,
                                     encoder.getLearningRate(),
                                     encoder.getMomentumRate())
@@ -492,7 +491,7 @@ class TrainerSAENetwork (SAENetwork) :
             if len(self._layers[layerIndex].getInputSize()) == 2 and \
                 len(getShape(self._layers[layerIndex].input[0])) == 2 :
                 imageShape=(1, self._layers[layerIndex].getInputSize()[1])
-                tileShape=(self._layers[layerIndex].getInputSize()[0], 1)
+                tileShape=(getShape(self._layers[layerIndex].input[0])[0], 1)
 
             self.writeWeights(layerIndex, globalEpoch + localEpoch)
             saveTiledImage(image=reconstructedInput,

--- a/trunk/modules/python/distill/net.py
+++ b/trunk/modules/python/distill/net.py
@@ -1,4 +1,4 @@
-import theano.tensor as t
+﻿import theano.tensor as t
 import theano
 from nn.net import TrainerNetwork, ClassifierNetwork
 from dataset.shared import isShared
@@ -235,7 +235,7 @@ class DistilleryTrainer (TrainerNetwork) :
         updates = self._compileUpdates(
             ((self._transFactor * deepXEntropy) +
              (1. - self._transFactor) * hardXEntropy +
-             self._compileRegularization()) / self.getNetworkInputSize()[0])
+             self._compileRegularization()))
 
         # override the training function
         givens = {self.getNetworkInput()[1]: self._trainData[index],

--- a/trunk/modules/python/nn/contiguousLayer.py
+++ b/trunk/modules/python/nn/contiguousLayer.py
@@ -1,4 +1,4 @@
-import six
+﻿import six
 from nn.layer import Layer
 from theano import dot
 from theano.tensor import tanh
@@ -33,10 +33,7 @@ class ContiguousLayer(Layer) :
         Layer.__init__(self, layerID, learningRate, momentumRate,
                        dropout, activation)
 
-        self._inputSize = inputSize
-        if isinstance(self._inputSize, six.integer_types) or \
-           len(self._inputSize) is not 2 :
-            self._inputSize = (1, inputSize)
+        self._inputSize = (None, inputSize[1])
         self._numNeurons = numNeurons
 
         # create weights based on the optimal distribution for the activation

--- a/trunk/modules/python/nn/convolutionalLayer.py
+++ b/trunk/modules/python/nn/convolutionalLayer.py
@@ -1,4 +1,4 @@
-from nn.layer import Layer
+﻿from nn.layer import Layer
 import numpy as np
 from theano.tensor import tanh
 
@@ -42,7 +42,7 @@ class ConvolutionalLayer(Layer) :
                              'Number of Channels must match in ' +
                              'inputSize and kernelSize')
 
-        self._inputSize = inputSize
+        self._inputSize = [None] + list(inputSize[1:])
         self._kernelSize = kernelSize
         self._downsampleFactor = downsampleFactor
 

--- a/trunk/modules/python/nn/costUtils.py
+++ b/trunk/modules/python/nn/costUtils.py
@@ -1,4 +1,4 @@
-import theano.tensor as t
+﻿import theano.tensor as t
 
 def cropExtremes(x) :
     # protect the loss function against producing NaNs/Inf
@@ -65,29 +65,23 @@ def calcSparsityConstraint(output, outShape, crop=True) :
                   (1. - sparseCon) * \
                   t.log((1. - sparseCon) / (1. - avgActivation)))
 
-def leastAbsoluteDeviation(a, batchSize=None, scaleFactor=1.) :
+def leastAbsoluteDeviation(a, scaleFactor=1.) :
     '''L1-norm provides 'Least Absolute Deviation' --
        built for sparse outputs and is resistent to outliers
 
        a           : input matrix
-       batchSize   : number of inputs in the batchs
        scaleFactor : scale factor for the regularization
     '''
     if not isinstance(a, list) :
         a = [a]
     absSum = sum([t.sum(t.abs_(arr)) for arr in a])
+    return t.mean(absSum) * scaleFactor
 
-    if batchSize is not None :
-        return t.mean(absSum // batchSize) * scaleFactor
-    else :
-        return absSum * scaleFactor
-
-def leastSquares(a, batchSize=None, scaleFactor=1.) :
+def leastSquares(a, scaleFactor=1.) :
     '''L2-norm provides 'Least Squares' --
        built for dense outputs and is computationally stable at small errors
 
        a           : input matrix
-       batchSize   : number of inputs in the batchs
        scaleFactor : scale factor for the regularization
 
        NOTE: a decent scale factor may be the 1. / numNeurons
@@ -95,11 +89,7 @@ def leastSquares(a, batchSize=None, scaleFactor=1.) :
     if not isinstance(a, list) :
         a = [a]
     sqSum = sum([t.sum(arr ** 2) for arr in a])
-
-    if batchSize is not None :
-        return t.mean(sqSum // batchSize) * scaleFactor
-    else :
-        return sqSum * scaleFactor
+    return t.mean(sqSum) * scaleFactor
 
 def computeJacobian(a, wrt, batchSize, inputSize, numNeurons) :
     '''Compute a jacobian for the matrix 'out' with respect to 'wrt'.

--- a/trunk/modules/python/nn/net.py
+++ b/trunk/modules/python/nn/net.py
@@ -1,4 +1,4 @@
-from nn.layer import Layer
+﻿from nn.layer import Layer
 import theano.tensor as t
 import theano
 from dataset.pickle import writePickleZip, readPickleZip
@@ -397,8 +397,7 @@ class TrainerNetwork (LabeledClassifierNetwork) :
         # be used back propagation, which runs output to input
         updates = compileUpdates(
             self._layers,
-            (xEntropy + self._regularization.calculate(self._layers)) / \
-            self.getNetworkInputSize()[0])
+            xEntropy + self._regularization.calculate(self._layers))
 
         # NOTE: This uses the lamda function as a means to consolidate the
         #       calling scheme. This saves us from later using conditionals in

--- a/trunk/modules/python/nn/reg.py
+++ b/trunk/modules/python/nn/reg.py
@@ -1,4 +1,4 @@
-class Regularization :
+﻿class Regularization :
     '''Object to save regularization constraints inside a network.
 
        regType     : Type of regularization ('L1' or 'L2')
@@ -23,13 +23,13 @@ class Regularization :
         if self._type == 'L1' :
             reg = leastAbsoluteDeviation(
                 [layer.getWeights()[0] for layer in layers],
-                batchSize=None, scaleFactor=self._scale)
+                scaleFactor=self._scale)
 
         # L2-norm provides 'Least Squares' --
         # built for dense outputs and is computationally stable at small errors
         elif self._type == 'L2' :
             reg = leastSquares(
                 [layer.getWeights()[0] for layer in layers],
-                batchSize=None, scaleFactor=self._scale)
+                scaleFactor=self._scale)
 
         return reg


### PR DESCRIPTION
Also, removed the scaling by batchSize from the costing functions. This was causing large learning rates that were not irregular.

closes #56 