### PR TITLE
Reload feature matrix

### DIFF
--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -82,7 +82,8 @@ class ContiguousAutoEncoder(ContiguousLayer, AutoEncoder) :
         from nn.layer import Layer
         from theano.tensor import round
         act = Layer._setActivation(self, out)
-        return round(act) if self._forceSparse else act
+        return round(act, mode='half_away_from_zero') \
+               if self._forceSparse else act
 
     def __getstate__(self) :
         '''Save layer pickle'''

--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -82,7 +82,8 @@ class ContiguousAutoEncoder(ContiguousLayer, AutoEncoder) :
         from nn.layer import Layer
         from theano.tensor import round
         act = Layer._setActivation(self, out)
-        return round(act, mode="half_away_from_zero") if self._forceSparse else act
+        return round(act, mode='half_away_from_zero') \
+               if self._forceSparse else act
 
     def __getstate__(self) :
         '''Save layer pickle'''

--- a/trunk/modules/python/ae/contiguousAE.py
+++ b/trunk/modules/python/ae/contiguousAE.py
@@ -159,9 +159,8 @@ class ContiguousAutoEncoder(ContiguousLayer, AutoEncoder) :
 
         # create the negative log likelihood function --
         # this is our cost function with respect to the original input
-        self._costs.append(calcLoss(
-            self.input[0].flatten(2), decodedInput, self._activation,
-            scaleFactor=1. / self.getInputSize()[1]))
+        self._costs.append(calcLoss(self.input[0].flatten(2), decodedInput,
+                                    self._activation))
         self._costLabels.append('Local Cost')
 
         # add regularization if it was user requested

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -152,6 +152,7 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         '''
         from nn.costUtils import calcLoss, leastSquares, \
                                  calcSparsityConstraint, compileUpdate
+        from dataset.shared import getShape
         ConvolutionalLayer.finalize(self, networkInput, layerInput)
 
         weightsBack = self._getWeightsBack()
@@ -186,8 +187,9 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         # this is our cost function with respect to the original input
         # NOTE: The jacobian was computed however takes much longer to process
         #       and does not help convergence or regularization. It was removed
-        self._costs.append(calcLoss(self.input[0], decodedInput, 
-                                    self._activation))
+        self._costs.append(calcLoss(
+            self.input[0], decodedInput, self._activation,
+            scaleFactor=1. / np.prod(self.getInputSize()[-3:])))
         self._costLabels.append('Local Cost')
 
         # add regularization if it was user requested
@@ -196,7 +198,8 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
             self._costs.append(regularization)
             self._costLabels.append('Regularization')
 
-        gradients = t.grad(t.sum(self._costs), self.getWeights())
+        gradients = t.grad(t.sum(self._costs) / getShape(networkInput[0])[0],
+                           self.getWeights())
         self._updates = compileUpdate(self.getWeights(), gradients,
                                       self._learningRate, self._momentumRate)
 

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -85,7 +85,8 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         from nn.layer import Layer
         from theano.tensor import round
         act = Layer._setActivation(self, out)
-        return round(act) if self._forceSparse else act
+        return round(act, mode='half_away_from_zero') \
+               if self._forceSparse else act
 
     def __getstate__(self) :
         '''Save layer pickle'''

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -189,7 +189,7 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         #       and does not help convergence or regularization. It was removed
         self._costs.append(calcLoss(
             self.input[0], decodedInput, self._activation,
-            scaleFactor=1. / np.prod(self.getInputSize()[-3:])))
+            scaleFactor=1. / self.getInputSize()[1]))
         self._costLabels.append('Local Cost')
 
         # add regularization if it was user requested

--- a/trunk/modules/python/ae/convolutionalAE.py
+++ b/trunk/modules/python/ae/convolutionalAE.py
@@ -85,7 +85,8 @@ class ConvolutionalAutoEncoder(ConvolutionalLayer, AutoEncoder) :
         from nn.layer import Layer
         from theano.tensor import round
         act = Layer._setActivation(self, out)
-        return round(act, mode="half_away_from_zero") if self._forceSparse else act
+        return round(act, mode='half_away_from_zero') \
+               if self._forceSparse else act
 
     def __getstate__(self) :
         '''Save layer pickle'''

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -387,6 +387,7 @@ class TrainerSAENetwork (SAENetwork) :
 
            NOTE: this uses theano.shared variables for optimized GPU execution
         '''
+        batchSize = getShape(self.getNetworkInput()[0])[0]
         from nn.costUtils import calcLoss, compileUpdate
         for ii, encoder in enumerate(self._layers) :
             # setup the layer-wise training functions --
@@ -419,7 +420,7 @@ class TrainerSAENetwork (SAENetwork) :
             # in additional to the existing costs.
             costs.append(calcLoss(netInput, decodedInput,
                                   self._layers[0].getActivation()))
-            gradients = t.grad(t.sum(costs), encoder.getWeights())
+            gradients = t.grad(t.sum(costs) / batchSize, encoder.getWeights())
             updates = compileUpdate(encoder.getWeights(), gradients,
                                     encoder.getLearningRate(),
                                     encoder.getMomentumRate())

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -1,5 +1,6 @@
 ﻿import theano.tensor as t
 import theano
+from matplotlib.scale import scale_factory
 from nn.net import ClassifierNetwork
 from ae.encoder import AutoEncoder
 import numpy as np
@@ -418,8 +419,10 @@ class TrainerSAENetwork (SAENetwork) :
 
             # recreate the updates using the greedy network reconstruction
             # in additional to the existing costs.
-            costs.append(calcLoss(netInput, decodedInput,
-                                  self._layers[0].getActivation()))
+            costs.append(calcLoss(
+                netInput, decodedInput, self._layers[0].getActivation(),
+                scaleFactor=1. / getShape(self.getNetworkInput()[0])[1] \
+                            if len(self.getNetworkInputSize()) == 4 else 1.))
             gradients = t.grad(t.sum(costs) / batchSize, encoder.getWeights())
             updates = compileUpdate(encoder.getWeights(), gradients,
                                     encoder.getLearningRate(),

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -142,9 +142,8 @@ class ClassifierSAENetwork (SAENetwork) :
         '''Read a directory of data to use as a feature matrix.
 
            targetpath : Path to the target directory
-           maxTargets : Limit the number of targets loaded into the Feature
-                        Matrix. If -1 load the entire directory, else randomize
-                        the data loaded from the directory.
+
+           return : format (numTargets, numChannels, rows, cols)
         '''
         import os
         from dataset.minibatch import makeContiguous
@@ -171,6 +170,7 @@ class ClassifierSAENetwork (SAENetwork) :
 
     def loadFeatureMatrix(self, target) :
         '''Load new target imagery into the Feature Matrix.
+
            target   : Target data for network. This is the way to provide the
                       unsupervised learning algorithm with a means to perform
                       classification.

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -115,6 +115,8 @@ class ClassifierSAENetwork (SAENetwork) :
 
         # remove the functions -- they will be rebuilt JIT
         if '_closeness' in dict : del dict['_closeness']
+        if '_updateTargetEncodings' in dict :
+            del dict['_updateTargetEncodings']
         return dict
 
     def __setstate__(self, dict) :
@@ -122,6 +124,8 @@ class ClassifierSAENetwork (SAENetwork) :
         # remove any current functions from the object so we force the
         # theano functions to be rebuilt with the new buffers
         if hasattr(self, '_closeness') : delattr(self, '_closeness')
+        if hasattr(self, '_updateTargetEncodings') :
+            delattr(self, '_updateTargetEncodings')
 
         # ensure the user input is remembered
         if hasattr(self, '_target') :

--- a/trunk/modules/python/ae/net.py
+++ b/trunk/modules/python/ae/net.py
@@ -1,6 +1,5 @@
 ﻿import theano.tensor as t
 import theano
-from matplotlib.scale import scale_factory
 from nn.net import ClassifierNetwork
 from ae.encoder import AutoEncoder
 import numpy as np

--- a/trunk/modules/python/builder/args.py
+++ b/trunk/modules/python/builder/args.py
@@ -49,6 +49,8 @@ def addUnsupDataParams (parser, base, multiLoad=False) :
     addSupDataParams(parser, base, multiLoad)
     parser.add_argument('--target', dest='targetDir', type=str, required=True,
                         help='Directory with target data to match.')
+    parser.add_argument('--maxTarget', dest='maxTarget', type=int, default=100,
+                        help='Directory with target data to match.')
 
 def addSupConvolutionalParams(parser) :
     '''Setup common ConvolutionalLayer options.'''

--- a/trunk/modules/python/nn/trainUtils.py
+++ b/trunk/modules/python/nn/trainUtils.py
@@ -18,7 +18,7 @@ def renameBestNetwork(lastSave, bestNetwork, log=None) :
 def _train(network, appName, dataPath, numEpochs=5, stop=1,
            synapse=None, base=None, kernel=None, neuron=None,
            learnC=None, learnF=None, numLayers=1, maxEpoch=np.inf,
-           log=None) :
+           resetLayer=None, log=None) :
     '''This trains a stacked autoencoder in a greedy layer-wise manner. This
        starts by train each layer in sequence for the specified number of
        epochs, then returns the network. This can be used to initialize a
@@ -33,7 +33,8 @@ def _train(network, appName, dataPath, numEpochs=5, stop=1,
     getLayer = lambda x, net: None if isSup(net) else x
 
     globalEpoch = lastBest = resumeEpoch(synapse)
-    resetLayer = resumeLayer(synapse)
+    if resetLayer is None :
+        resetLayer = resumeLayer(synapse)
     if synapse is not None :
         kernel, neuron, learnC, learnF = resumeData(synapse)
     lastSave = buildPickleInterim(
@@ -109,7 +110,8 @@ def _train(network, appName, dataPath, numEpochs=5, stop=1,
 
 def trainUnsupervised(network, appName, dataPath, numEpochs=5, stop=1,
                       synapse=None, base=None, kernel=None, neuron=None, 
-                      learnC=None, learnF=None, maxEpoch=np.inf, log=None) :
+                      learnC=None, learnF=None, maxEpoch=np.inf,
+                      resetLayer=None, log=None) :
     '''This trains a stacked autoencoder in a greedy layer-wise manner. This
        starts by train each layer in sequence for the specified number of
        epochs, then returns the network. This can be used to initialize a
@@ -122,7 +124,8 @@ def trainUnsupervised(network, appName, dataPath, numEpochs=5, stop=1,
     _train(network=network, appName=appName, dataPath=dataPath,
            numEpochs=numEpochs, stop=stop, synapse=synapse, base=base,
            kernel=kernel, neuron=neuron, learnC=learnC, learnF=learnF, 
-           numLayers=network.getNumLayers(), maxEpoch=maxEpoch, log=log)
+           numLayers=network.getNumLayers(), maxEpoch=maxEpoch,
+           resetLayer=resetLayer, log=log)
 
 def trainSupervised (network, appName, dataPath, numEpochs=5, stop=30,
                      synapse=None, base=None, kernel=None, neuron=None, 

--- a/trunk/projects/unsupervised/classifySAEApp.py
+++ b/trunk/projects/unsupervised/classifySAEApp.py
@@ -3,10 +3,12 @@ from dataset.ingest.unlabeled import ingestImagery
 from builder.args import addLoggingParams, addUnsupDataParams
 from builder.profiler import setupLogging
 
-def createNetworks(target, netFiles, prof, debug) :
+def createNetworks(target, maxTarget, batchSize, netFiles, prof, debug) :
     '''Read and create each network initialized with the target dataset.'''
     from ae.net import ClassifierSAENetwork
-    return [ClassifierSAENetwork(target, syn, prof, debug) for syn in netFiles]
+    nets = [ClassifierSAENetwork(syn, prof, debug) for syn in netFiles]
+    [net.loadFeatureMatrix(target, maxTarget) for net in nets]
+    return nets
 
 def sortDataset(netList, imagery, percentile=.95, debug=False) :
     '''Test the imagery for how close it is to the target data. This also sorts
@@ -82,8 +84,9 @@ if __name__ == '__main__' :
                                 log=log)
 
     # load all networks initialized to the target imagery
-    nets = createNetworks(options.targetDir, options.synapse, prof,
-                          options.debug)
+    nets = createNetworks(options.targetDir, options.maxTarget,
+                          options.batchSize, options.synapse,
+                          prof, options.debug)
 
     # test the training data for similarity to the target
     sortDataset(nets, test.get_value(borrow=True), 

--- a/trunk/projects/unsupervised/classifySAEApp.py
+++ b/trunk/projects/unsupervised/classifySAEApp.py
@@ -6,8 +6,9 @@ from builder.profiler import setupLogging
 def createNetworks(target, maxTarget, batchSize, netFiles, prof, debug) :
     '''Read and create each network initialized with the target dataset.'''
     from ae.net import ClassifierSAENetwork
-    nets = [ClassifierSAENetwork(syn, prof, debug) for syn in netFiles]
-    [net.loadFeatureMatrix(target, maxTarget) for net in nets]
+    nets = [ClassifierSAENetwork(maxTarget, syn, prof, debug) \
+            for syn in netFiles]
+    [net.loadFeatureMatrix(target) for net in nets]
     return nets
 
 def sortDataset(netList, imagery, percentile=.95, debug=False) :

--- a/trunk/projects/unsupervised/classifySAETrainer.py
+++ b/trunk/projects/unsupervised/classifySAETrainer.py
@@ -58,8 +58,9 @@ if __name__ == '__main__' :
     options.synapse = tmpNet
 
     # train the SAE
-    net = ClassifierSAENetwork(options.targetDir, options.synapse, prof,
+    net = ClassifierSAENetwork(options.maxTarget, options.synapse, prof,
                                options.debug)
+    net.loadFeatureMatrix(options.targetDir)
 
     # test the training data for similarity to the target
     testCloseness(net, test.get_value(borrow=True))

--- a/trunk/projects/unsupervised/tools/retrainContiguous.py
+++ b/trunk/projects/unsupervised/tools/retrainContiguous.py
@@ -1,0 +1,60 @@
+﻿from ae.net import TrainerSAENetwork, ClassifierSAENetwork
+from builder.profiler import setupLogging
+from builder.sae import setupCommandLine, buildNetwork
+from dataset.ingest.unlabeled import ingestImagery
+from nn.trainUtils import trainUnsupervised
+
+from dataset.shared import getShape
+
+tmpNet = './local.pkl.gz'
+
+if __name__ == '__main__' :
+    '''Build and train an SAE, then test against a target example.'''
+    from ..classifySAETrainer import testCloseness
+    from nn.contiguousLayer import ContiguousLayer
+
+    options = setupCommandLine()
+
+    if options.synapse is None :
+        raise ValueError('Please specify a Synapse file to start.')
+
+    # setup the logger
+    log, prof = setupLogging (options, 'SAE-Classification Benchmark')
+
+    # NOTE: The pickleDataset will silently use previously created pickles if
+    #       one exists (for efficiency). So watch out for stale pickles!
+    train, test = ingestImagery(filepath=options.data, shared=True,
+                                batchSize=options.batchSize, 
+                                holdoutPercentage=options.holdout,
+                                log=log)
+
+    # create the stacked network
+    trainer = TrainerSAENetwork(train, test, options.synapse, prof,
+                                options.debug)
+
+    # remove the contiguous layers
+    while isinstance(trainer.getLayer(-1), ContiguousLayer) :
+        trainer.removeLayer()
+
+    # rebuild the contiguous layers -- based on the new specifications
+    options.kernel = []
+    options.kernelSize = []
+    buildNetwork(trainer, getShape(train)[1:], options, prof=prof)
+
+    # train the SAE
+    trainUnsupervised(trainer, __file__, options.data,
+                      numEpochs=options.limit, stop=options.stop,
+                      synapse=options.synapse, base=options.base,
+                      kernel=options.kernel, neuron=options.neuron,
+                      learnC=options.learnC, learnF=options.learnF,
+                      maxEpoch=options.epoch, log=log)
+    trainer.save(tmpNet)
+    options.synapse = tmpNet
+
+    # train the SAE
+    net = ClassifierSAENetwork(options.maxTarget, options.synapse, prof,
+                               options.debug)
+    net.loadFeatureMatrix(options.targetDir)
+
+    # test the training data for similarity to the target
+    testCloseness(net, test.get_value(borrow=True))


### PR DESCRIPTION
Closes #58 #59 #66 #68
This fixes several issues associated with training and optimization of sae networks. Refillable Feature matrix and allowing fixed feature sizes were needed to quickly resort our data based on increasingly larger datasets. 

The revert to scaled loss functions was due to retraining requiring too much customization in the learningRates per layer. This allows better common learning rates and easier usage. 